### PR TITLE
Fix spelling errors

### DIFF
--- a/guides/hack/01-types/02-type-system.md
+++ b/guides/hack/01-types/02-type-system.md
@@ -73,7 +73,7 @@ There are valid uses for `mixed`, but generally you want to be as specific as po
 
 ## `this`
 
-`this` means that a class method returns an object of the same class as the calling method. You can use it to return an instance of an object from a `static` class method where you are returning something lke `new static()`.
+`this` means that a class method returns an object of the same class as the calling method. You can use it to return an instance of an object from a `static` class method where you are returning something like `new static()`.
 
 @@ type-system-examples/this.php @@
 

--- a/guides/hack/01-types/06-refining.md
+++ b/guides/hack/01-types/06-refining.md
@@ -12,7 +12,7 @@ There is also a special function:
 
 - `invariant(<bool expression of fact>, "Message if not")`
 
-that can be used outside control-flow situation. It is essentially an assert to the typecheker that what you claim in the boolean statement is fact and true.
+that can be used outside control-flow situation. It is essentially an assert to the typechecker that what you claim in the boolean statement is fact and true.
 
 In any of the refining scenarios below, you can use `invariant()` as opposed to the conditional check.
 

--- a/guides/hack/03-async/04-blocks.md
+++ b/guides/hack/03-async/04-blocks.md
@@ -11,7 +11,7 @@ The syntax for an async block is:
 ```
 async {
   // grouped together calls, usually await.
-  < satements >
+  < statements >
 }
 ```
 

--- a/guides/hack/03-async/05-utility-functions.md
+++ b/guides/hack/03-async/05-utility-functions.md
@@ -5,7 +5,7 @@ Async can be used effectively with the built-in infrastructure in HHVM. This inf
 * `async`, `await`, `Awaitable`
 * `HH\Asio\v()`, `HH\Asio\m()`
 
-However, there are cases when you want to convert some collection of values to awaitables or you want to filter some awaitables out of a collection of awaiables. These type of scenarios come up when you are creating multiple awaitables to await in parallel. 
+However, there are cases when you want to convert some collection of values to awaitables or you want to filter some awaitables out of a collection of awaitables. These type of scenarios come up when you are creating multiple awaitables to await in parallel. 
 
 You can use functions like `array_filter()`, or the methods on the Hack collection classes, etc. to do this mapping and filtering. But there exists a whole collection of concise and simply named utility functions that will make your code more streamlined. 
 
@@ -89,7 +89,7 @@ That is because `HH\Asio\v()` takes an `Traversable<Awaitable<T>>` and return an
 
 However, when you want to return the `tuple($a, $b)`, `$a` is an `X`, `b` is an `int`, but the type-checker doesn't realize that since it thinks these should be the hybrid union type it created above.
 
-So we need to explictly assert what we know to be true in order to make the type checker happy.
+So we need to explicitly assert what we know to be true in order to make the type checker happy.
 
 ```
 assert ($a instanceof X);

--- a/guides/hack/03-async/07-guidelines.md
+++ b/guides/hack/03-async/07-guidelines.md
@@ -1,6 +1,6 @@
 # Async General Guidelines
 
-It might be tempting to just throw `async`, `await` and `Awaitable` on all your code and go on with your life. And while it is ok to have more `async` functions than not -- in fact, you should generally not be afraid to make a function `async` since there is no performance penalty for doing so -- there are some guidelines you should follow in order to make the most efficient use of `async`.
+It might be tempting to just throw `async`, `await` and `Awaitable` on all your code and go on with your life. And while it is OK to have more `async` functions than not -- in fact, you should generally not be afraid to make a function `async` since there is no performance penalty for doing so -- there are some guidelines you should follow in order to make the most efficient use of `async`.
 
 ## Be liberal, but careful, with async
 
@@ -75,7 +75,7 @@ In the example above, we reduce the number of roundtrips to the server containin
 
 The `await HH\Asio\later()` in `Batcher::go()` basically allows `Batcher::go()` to be deferred until other pending awaitables have run.
 
-So, `await HH\Asio\v(array(b_one..., b_two...));` has two pending awaitables. If `b_one()` is called first, it calls `Batcher::lookup()`, which calls `Batcher::go()`, which reschdules via `later()`. Then HHVM looks for other pending awaitables. `b_two()` is also pending. It calles `Batcher::lookup()` and then it gets suspended via `await self::$aw` because `Batcher::$aw` is not `null` any longer. Now `Batcher::go()` resumes, fetches and returns the result.
+So, `await HH\Asio\v(array(b_one..., b_two...));` has two pending awaitables. If `b_one()` is called first, it calls `Batcher::lookup()`, which calls `Batcher::go()`, which reschedules via `later()`. Then HHVM looks for other pending awaitables. `b_two()` is also pending. It calls `Batcher::lookup()` and then it gets suspended via `await self::$aw` because `Batcher::$aw` is not `null` any longer. Now `Batcher::go()` resumes, fetches and returns the result.
 
 ## Don't forget to await an awaitable
 

--- a/guides/hack/04-collections/01-intro.md
+++ b/guides/hack/04-collections/01-intro.md
@@ -52,7 +52,7 @@ There are seven collections in Hack:
 
 Type | Description
 -----|------------
-**Vector** | Mutable, `int`eger-indexed, ordered sequence of values. Values can be of any type. The indecies start at `0` and end at `n-1`, where `n` is the number of elements.
+**Vector** | Mutable, `int`eger-indexed, ordered sequence of values. Values can be of any type. The indicies start at `0` and end at `n-1`, where `n` is the number of elements.
 **ImmVector** | A immutable version of `Vector`. Once the `ImmVector` is created, elements cannot be changed, removed or added.
 **Map** | Mutable, `string` or `int`eger-indexed, ordered sequence of values. Values can be of any type. Order is remembered. This is most similar to the `array` in usage.
 **ImmMap** | A immutable version of `Map`. Once the `ImmMap` is created, elements cannot be changed, removed or added.

--- a/guides/hack/04-collections/02-semantics.md
+++ b/guides/hack/04-collections/02-semantics.md
@@ -1,6 +1,6 @@
 # Collection Semantics
 
-In general, Hack collections should be your first choice when deciding between them and arrays for new code. They provide the readability, performance and type-checkablity needed, without sacrificing much in terms of flexibility.
+In general, Hack collections should be your first choice when deciding between them and arrays for new code. They provide the readability, performance and type-checkability needed, without sacrificing much in terms of flexibility.
 
 That said, there is one key area where you must be cognizant of the differences between collections and arrays.
 

--- a/guides/hack/05-XHP/02-basic-usage.md
+++ b/guides/hack/05-XHP/02-basic-usage.md
@@ -6,7 +6,7 @@ XHP is a syntax to create actual Hack objects, called XHP objects. They are mean
 
 * you can call methods on XHP objects
 * you can call the `is_xxx` methods on them (e.g. `is_object()`).
-* they are instances of XHP clases, with names starting with `:` and all are children of `:xhp`.
+* they are instances of XHP classes, with names starting with `:` and all are children of `:xhp`.
 
 You create the XHP objects with XHP tags instead of `new`.
 

--- a/guides/hack/05-XHP/03-typing.md
+++ b/guides/hack/05-XHP/03-typing.md
@@ -25,7 +25,7 @@ Method | Description
 -------|------------
 `appendChild(mixed $child): this` | Adds $child to the end of the XHP object's array of children. If $child is an `array`, each item in the array will be appended.
 `categoryOf(string $cat): bool` | Returns whether the XHP object belongs to the category named `$cat`
-`getAttribute(string $name): mixed` | Returns the value of the XHP object's attribute named `$name`. If the attribute is not set, `null` is returned, unless the attribute is required, in which case `XHPAttributeRequiredException` is thrown. If the attribute is not declared or does not exist, then `XHPAttributeNotSupportedException` is thrown. If the attribute you are reading is statically known, use `$this->:name` style sytanx instead for better typechecker coverage.
+`getAttribute(string $name): mixed` | Returns the value of the XHP object's attribute named `$name`. If the attribute is not set, `null` is returned, unless the attribute is required, in which case `XHPAttributeRequiredException` is thrown. If the attribute is not declared or does not exist, then `XHPAttributeNotSupportedException` is thrown. If the attribute you are reading is statically known, use `$this->:name` style syntax instead for better typechecker coverage.
 `getAttributes(): Map<string, mixed>` | Returns the XHP object's array of attributes, as a cloned copy.
 `getChildren(?string $selector = null): Vector<XHPChild>` | Returns the XHP object's children. If `$selector` is `null`, all children are returned. If `$selector` starts with `%`, all children belonging to the category named by `$selector` are returned. Otherwise, all children that are `instanceof` the class named by `$selector` are returned. 
 `getFirstChild(?string $selector = null):): ?XHPChild` | Returns the XHP object's first child. If `$selector` is `null`, the true first child is returned. Otherwise, the first child that matches `$selector` (or `null`) is returned.
@@ -33,7 +33,7 @@ Method | Description
 `isAttributeSet(string $name): bool` | Returns whether the attribute with name `$name` is set.
 `prependChild(mixed $child): this` | Adds $child to the beginning of the XHP object's array of children. If $child is an `array`, each item in the array will be appended.
 `replaceChildren(...): this` | Replaces all the children of this XHP Object with the variable number of children passed to this method.
-`setAttribute(string $name, mixed $val): this` | Sets the value of the XHP object's attribute named `$name`. The value will be checked against the attribute's type, and if they don't match, `XHPInvalidAttributeException` is thrown. If the attribute is not declared or does not exist, then `XHPAttributeNotSupportedException` is thrown. If the attribute you are reading is statically known, use `$this->:name = $value` style sytanx instead for better typechecker coverage.
+`setAttribute(string $name, mixed $val): this` | Sets the value of the XHP object's attribute named `$name`. The value will be checked against the attribute's type, and if they don't match, `XHPInvalidAttributeException` is thrown. If the attribute is not declared or does not exist, then `XHPAttributeNotSupportedException` is thrown. If the attribute you are reading is statically known, use `$this->:name = $value` style syntax instead for better typechecker coverage.
 `setAttributes(KeyedTraversable<string, mixed> $attrs): this` | Replaces the XHP object's array of attributes with `$attrs`. Same errors can apply as `setAttribute()`.
 
 @@ typing-examples/use-object-methods.php @@

--- a/guides/hack/05-XHP/04-extending.md
+++ b/guides/hack/05-XHP/04-extending.md
@@ -27,7 +27,7 @@ Here are the types allowed for attributes. Note if there is a problem with using
 * Hack [enum](../enums/intro.md) names, checked by [`Enum::isValid()`](../enums/functions.md) at runtime.
 * Custom enums inline with the attribute in the form of `enum {item, item...}`. All values must be scalar so they can be converted to strings. These enums are not Hack enums.
 * Class or interface names, checked by `instanceof()`. 
-* [Generic](../generics/intro.md) types, with type arguements, although they are not enforced at runtime.
+* [Generic](../generics/intro.md) types, with type arguments, although they are not enforced at runtime.
 
 You access an attribute within code just like a normal Hack property, but prefixed with a colon `:`. 
 
@@ -83,7 +83,7 @@ The `XHPHelpers` trait implements three behaviors:
 
 * Transferring attributes from one object to the object returned from its `render()` method.
 * Giving each object a unique `id` attribute.
-* Manging the `class` attribute.
+* Managing the `class` attribute.
 
 ### Attribute Transfer
 

--- a/guides/hack/07-lambdas/01-intro.md
+++ b/guides/hack/07-lambdas/01-intro.md
@@ -25,6 +25,6 @@ PHP provides the keyword `use` to capture variables from the enclosing scope. Ha
 
 @@ intro-examples/capture-variables.php @@
 
-Notice in `addLastName()` we are using the passed in parameter `$lastname` directly wihtin the lambda whereas in `addLastNameTraditional`, the parameter `$lastName` must be explictly captured and called out in a `use`.
+Notice in `addLastName()` we are using the passed in parameter `$lastname` directly within the lambda whereas in `addLastNameTraditional`, the parameter `$lastName` must be explicitly captured and called out in a `use`.
 
 **NOTE**: All captured variables are captured by value; capturing by reference is *not supported*. 

--- a/guides/hack/12-enums/01-intro.md
+++ b/guides/hack/12-enums/01-intro.md
@@ -48,6 +48,6 @@ However, you can use simple casting to convert a member value of an enum to its 
 
 ### Implicit Casting
 
-By using the `as` constraint operator, you can make it so casting to the underlying type is implict.
+By using the `as` constraint operator, you can make it so casting to the underlying type is implicit.
 
 @@ intro-examples/implicit-casting.php @@

--- a/guides/hack/12-enums/02-functions.md
+++ b/guides/hack/12-enums/02-functions.md
@@ -18,7 +18,7 @@ This example shows how `assert()` can be used to get the `Day` enum member value
 
 This example shows how `assertAll()` can be used to get the `Day` enum member values given a `Vector` of its underlying type `int`. Since there is a check making sure the provided `int`s in the `Vector` are in the proper range, we can be confident that we won't get a runtime exception for using a value that doesn't exist in the enum.
 
-Note that `assertAll()` returns a `Container` (which is a child of `Traversable`, so in order we need to create a new `Vector` from that `Container` and pass it to `get_lastest_day()`. 
+Note that `assertAll()` returns a `Container` (which is a child of `Traversable`, so in order we need to create a new `Vector` from that `Container` and pass it to `get_latest_day()`. 
 
 ## `coerce()`
 

--- a/guides/hack/16-typechecker/05-modes.md
+++ b/guides/hack/16-typechecker/05-modes.md
@@ -34,7 +34,7 @@ means that the typechecker is checking everything. If at all possible, start new
 -- From strict mode, you *can* call into Hack code in partial and decl mode.
 - The only code allowed at the top-level are `require`, `require_once`, `include`, `include_once`, `namespace`, `use`, and statements that define classes, functions, constants (e.g., using `const`), etc.
 - No by-reference `&` anywhere.
-- No accessing super globals.
+- No accessing superglobals.
 
 Strict is actually the mode you want to strive to. The entire typechecker goodness is at your disposal and should ensure zero runtime type errors.
 


### PR DESCRIPTION
Mostly found with aspell:

```
$ for file in `find . -name \*.md | grep -v 99`; do aspell check $file; done
```