### PR TITLE
Adding gotcha for Memoize Attribute and Mutable return values. 

### DIFF
--- a/guides/hack/44-attributes/04-special.md
+++ b/guides/hack/44-attributes/04-special.md
@@ -67,7 +67,7 @@ interface IMemoizeParam {
 - While performance can rise, memory usage will also rise because you are caching results in memory.
 - HHVM can actually free memory used by memoized results if needed. Thus, sometimes, a memoized result might be removed from memory and the time consuming operation will happen again. This can be a good thing though as HHVM is managing the memory for you properly.
 - HHVM makes no guarantees about the side effects your memoization may have.
-- Your function will return the same object, which means that, if your object mutated, all return values for previous and future calls to the function will have that mutation. Sometimes that's exactly the behaviour we want. Say, a singleton. However, if we are just caching a result of a fetch, it could be disastrous if someone erroneously changed that returned object in-place and suddenly every other caller is using a corrupted object. To avoid that, you can use [`Immutable Collections`](/hack/collections/classes#immutable-collections) or design your own immutable return type.
+- Your function will return the same object, which means that, if your object mutated, all return values for previous and future calls to the function will have that mutation. Sometimes that's exactly the behaviour we want - say, a singleton. However, if we are just caching a result of a fetch, it could be disastrous if someone erroneously changed that returned object in-place and suddenly every other caller is using a corrupted object. To avoid that, you can use [`Immutable Collections`](/hack/collections/classes#immutable-collections) or design your own immutable return type.
 
 ## `<<__Deprecated($message, $sample_rate = 1)>>`
 

--- a/guides/hack/44-attributes/04-special.md
+++ b/guides/hack/44-attributes/04-special.md
@@ -67,6 +67,7 @@ interface IMemoizeParam {
 - While performance can rise, memory usage will also rise because you are caching results in memory.
 - HHVM can actually free memory used by memoized results if needed. Thus, sometimes, a memoized result might be removed from memory and the time consuming operation will happen again. This can be a good thing though as HHVM is managing the memory for you properly.
 - HHVM makes no guarantees about the side effects your memoization may have.
+- Your function will return the same object, which means that, if your object mutated, all return values for previous and future calls to the function will have that mutation. Sometimes that's exactly the behaviour we want. Say, a singleton. However, if we are just caching a result of a fetch, it could be disastrous if someone erroneously changed that returned object in-place and suddenly every other caller is using a corrupted object. To avoid that, you can use [`Immutable Collections`](/hack/collections/classes/#immutable-collections) or design your own immutable return type.
 
 ## `<<__Deprecated($message, $sample_rate = 1)>>`
 

--- a/guides/hack/44-attributes/04-special.md
+++ b/guides/hack/44-attributes/04-special.md
@@ -67,7 +67,7 @@ interface IMemoizeParam {
 - While performance can rise, memory usage will also rise because you are caching results in memory.
 - HHVM can actually free memory used by memoized results if needed. Thus, sometimes, a memoized result might be removed from memory and the time consuming operation will happen again. This can be a good thing though as HHVM is managing the memory for you properly.
 - HHVM makes no guarantees about the side effects your memoization may have.
-- Your function will return the same object, which means that, if your object mutated, all return values for previous and future calls to the function will have that mutation. Sometimes that's exactly the behaviour we want. Say, a singleton. However, if we are just caching a result of a fetch, it could be disastrous if someone erroneously changed that returned object in-place and suddenly every other caller is using a corrupted object. To avoid that, you can use [`Immutable Collections`](/hack/collections/classes/#immutable-collections) or design your own immutable return type.
+- Your function will return the same object, which means that, if your object mutated, all return values for previous and future calls to the function will have that mutation. Sometimes that's exactly the behaviour we want. Say, a singleton. However, if we are just caching a result of a fetch, it could be disastrous if someone erroneously changed that returned object in-place and suddenly every other caller is using a corrupted object. To avoid that, you can use [`Immutable Collections`](/hack/collections/classes#immutable-collections) or design your own immutable return type.
 
 ## `<<__Deprecated($message, $sample_rate = 1)>>`
 


### PR DESCRIPTION
Memoize could be dangerous if people do in-place mutation of the returned values. Making this clear in the documentation. 