### PR TITLE
Corrected H2 capitalization in Hack User Documentation.

### DIFF
--- a/guides/hack/20-types/06-refining.md
+++ b/guides/hack/20-types/06-refining.md
@@ -28,7 +28,7 @@ Remember that `mixed` represent any annotatable type (except a nullable type). `
 
 @@ refining-examples/mixed.php @@
 
-## Object instance checks
+## Object Instance Checks
 
 Sometimes you want to know whether an object is a child of a parent class or implements a particular interface. You can use the `instanceof` check to help make this determination. 
 

--- a/guides/hack/22-async/07-guidelines.md
+++ b/guides/hack/22-async/07-guidelines.md
@@ -2,7 +2,7 @@
 
 It might be tempting to just throw `async`, `await` and `Awaitable` on all your code and go on with your life. And while it is OK to have more `async` functions than not -- in fact, you should generally not be afraid to make a function `async` since there is no performance penalty for doing so -- there are some guidelines you should follow in order to make the most efficient use of `async`.
 
-## Be liberal, but careful, with async
+## Be Liberal, but Careful, with Async
 
 If you are struggling as to whether your code should be async or not, you can generally start with the answer //yes// and find a reason to say //no//. For example, a simple //hello world// program can be made async with no performance penalty. You will likely not get any gain, but you will not get any loss -- and it is setup for any future changes that may require async.
 
@@ -14,7 +14,7 @@ These two programs are, for all intents and purposes, equivalent.
 
 Just make sure you are following the rest of the guidelines. Async is great, but you still have to consider things like caching, batching and efficiency.
 
-## Use async extensions
+## Use Async Extensions
 
 For the common cases where async would provide maximum benefit, HHVM provides convenient extension libraries to help make writing code much easier. Depending on your use case scenario, you should liberally use:
 
@@ -23,7 +23,7 @@ For the common cases where async would provide maximum benefit, HHVM provides co
 * [McRouter](./extensions.md#mcrouter) for memcached-based operations.
 * [Streams](./extensions.md#streams) for stream-based resource operations.
 
-## Do not use async in loops
+## Do Not Use Async in Loops
 
 If you only remember one rule, remember this:
 
@@ -42,7 +42,7 @@ Instead, you will want to use our async-aware mapping function, [`vm()`](link to
 
 @@ guidelines-examples/await-no-loop.php @@
 
-## Considering data dependencies is important
+## Considering Data Dependencies Is Important
 
 Possibly the most important aspect in learning how to structure async code is understanding data dependency patterns. Here is the general flow of how to make sure your async code is data dependency correct:
 
@@ -65,7 +65,7 @@ The above example follows our flow:
 2. One function for the bundle of data operations (post text and comment count).
 3. One top function that coordinates everything.
 
-## Consider batching
+## Consider Batching
 
 Wait handles can be rescheduled. This means that it will be sent back to the queue of the scheduler, waiting until other awaitables have run. Batching can be a good use of rescheduling. For example, say you have high latency lookup of data, but you can send multiple keys for the lookup in a single request.
 
@@ -77,7 +77,7 @@ The `await HH\Asio\later()` in `Batcher::go()` basically allows `Batcher::go()` 
 
 So, `await HH\Asio\v(array(b_one..., b_two...));` has two pending awaitables. If `b_one()` is called first, it calls `Batcher::lookup()`, which calls `Batcher::go()`, which reschedules via `later()`. Then HHVM looks for other pending awaitables. `b_two()` is also pending. It calls `Batcher::lookup()` and then it gets suspended via `await self::$aw` because `Batcher::$aw` is not `null` any longer. Now `Batcher::go()` resumes, fetches and returns the result.
 
-## Don't forget to await an awaitable
+## Don't Forget to Await an Awaitable
 
 What do you think happens here?
 
@@ -85,7 +85,7 @@ What do you think happens here?
 
 The answer is undefined. You might get all three echoes. You might only get the first echo. You might get nothing at all. The only way to guarantee that `speak()` will run to completion is to `await` it. `await` is the trigger to the async scheduler that allows HHVM to appropriately suspend and resume `speak()`; otherwise, the async scheduler will be provide no guarantees with respect to `speak()`.
 
-## Minimize undesired side effects
+## Minimize Undesired Side Effects
 
 In order to minimize any unwanted side effects (e.g., ordering disparities), your creation and awaiting of awaitables should happen as close as possible.
 
@@ -95,7 +95,7 @@ In the above example, `possible_side_effects()` could cause some undesired behav
 
 Basically, don't depend on the order of output between runs of the same code. i.e, don't write async code where ordering is important and instead use dependencies via awaitables and `await`.
 
-## Memoization may be good. But only awaitables
+## Memoization May Be Good. But Only Awaitables
 
 Given that async is commonly used in operations that are time-consuming, memoizing (i.e., caching) the result of an async call can definitely be worthwhile.
 
@@ -122,7 +122,7 @@ Instead, memoize the awaitable
 
 This may seem unintuitive, because the function `await`s every time it’s executed, even on the cache-hit path. But that’s fine: on every execution except the first, `$handle` is not `null`, so a new instance of `time_consuming()` will not be started. The result of the one existing instance will be shared.
 
-## Use lambdas where possible
+## Use Lambdas Where Possible
 
 [Lambdas](../lambdas/introduction.md) can cut down on code verbosity that comes with writing full closure syntax. They are quite useful in conjunction with the [async utility helpers](utility-functions.md). 
 
@@ -130,7 +130,7 @@ For example, look how the following three ways to accomplish the same thing can 
 
 @@ guidelines-examples/lambdas.php @@
 
-## Use `join` in non-async functions
+## Use `join` in Non-async Functions
 
 Imagine you are making a call to an `async` function `join_async()` from a non-async scope. In order to obtain your desired results, you must `join()` in order to get the result from an awaitable. 
 
@@ -138,11 +138,11 @@ Imagine you are making a call to an `async` function `join_async()` from a non-a
 
 This scenario normally occurs in the global scope (but can occur anywhere).
 
-## Remember async is NOT multi-threading
+## Remember Async Is NOT Multi-threading
 
 Async functions are not running at the same time. They are CPU sharing via changes in wait state in executing code (i.e., preemptive multitasking). Async still lives in the single-threaded world of normal PHP and Hack.
 
-## `await` is not an expression
+## `await` Is Not an Expression
 
 You can use `await` in three places:
 

--- a/guides/hack/23-collections/10-examples.md
+++ b/guides/hack/23-collections/10-examples.md
@@ -51,7 +51,7 @@ This example shows you how to use `lazy()` on a rather large collection and the 
 
 @@ examples-examples/indexish.php @@
 
-## Creating a new collection
+## Creating a New Collection
 
 The current [concrete](./04-classes.md) collection classes are marked as final. That is, they cannot be directly extended and sub-classed. However, you can create new collection classes by using the [interfaces](./03-interfaces.md) provided. This example won't create a full-blown new collection since so many methods would have to be implemented from [`Iterable<T>`](./semantics.md#core-interfaces) with much more scrutiny and detail than what is presented here.
 

--- a/guides/hack/24-XHP/06-guidelines.md
+++ b/guides/hack/24-XHP/06-guidelines.md
@@ -16,7 +16,7 @@ This validation is on by default. You can turn it off by running the following c
 :xhp::$ENABLE_VALIDATION=false
 ```
 
-## Use Contexts To Access Higher Level Information
+## Use Contexts to Access Higher Level Information
 
 If you have a parent object, and you want to give information to some object further down the UI tree (e.g., <ul> to <li>), you can set a context for those lower objects and the lower objects can retrieve them. You use `setContext()` and `getContext()`
 
@@ -27,7 +27,7 @@ If you have a parent object, and you want to give information to some object fur
 Context is only passed down the tree at render time. In general, you should only call `getContext()` in the `render()` method of the child.
 
 
-## Don't Add Public Methods To Your XHP Components
+## Don't Add Public Methods to Your XHP Components
 
 Basically, your XHP classes should consist of children, attributes and a `protected render()` / `protected async renderAsync()` function. Basically, a user should be able to use tags, `toString()` and the [XHP object interfaces](./typing.md#xhp-object-interfaces) only to deal with your object.
 

--- a/guides/hack/28-enums/01-introduction.md
+++ b/guides/hack/28-enums/01-introduction.md
@@ -22,7 +22,7 @@ The name of the enum has to be namespace unique, and members of the enum must be
 
 @@ introduction-examples/simple.php @@
 
-## Enum member values
+## Enum Member Values
 
 The values of enum members must match the type of the enum. If your enum is marked as being an `int`, enum, then the member values must be `int`. Also, the values must be able to be statically evaluated. In other words, no variables, etc. can be used as part of an enum member value.
 
@@ -36,7 +36,7 @@ To access a member value, you follow the similar syntax as class constants
 
 **NOTE**: There is no notion of sequential, implicit values to enum members. For example, if you set the first member to `0`, the next member doesn't, by default, have the value of `1`. Each enum member must have an explicit value assigned to it. 
 
-## Casting to underlying type
+## Casting to Underlying Type
 
 While enums have underlying types, they are not interchangeable. The enum is a distinct type. And like any other types, you cannot, for example, pass an `int` to a function expecting an enum, or an enum value to a function expecting a `string`. 
 


### PR DESCRIPTION
Not a technical issue, but capitalization should be consistent.