### PR TITLE
Don't include list of placeholders in AsyncMysqlConnection::queryf example

### DIFF
--- a/guides/hack/99-api-examples/class.AsyncMysqlConnection/queryf/001-basic-usage.md
+++ b/guides/hack/99-api-examples/class.AsyncMysqlConnection/queryf/001-basic-usage.md
@@ -1,15 +1,1 @@
-The following example shows how to use `AsyncMysqlConneciton::queryf`. First you get a connection from an `AsyncMysqlConnectionPool`; then you decide what parameters you want to pass as query placeholders. Supported placeholders are:
-
-*   `%T`   table name
-*   `%C`   column name
-*   `%s`   nullable string (will be escaped)
-*   `%d`   integer
-*   `%f`   float
-*   `%=s`  nullable string comparison - expands to either:
-    *          `= 'escaped_string'`
-    *          `IS NULL`
-*   `%=d`  nullable integer comparison
-*   `%=f`  nullable float comparison
-*   `%Q`   raw SQL query. The typechecker intentionally does not recognize
-*          this, however, you can use it in combination with `// UNSAFE`
-*          if absolutely required 
+The following example shows how to use `AsyncMysqlConneciton::queryf`. First you get a connection from an `AsyncMysqlConnectionPool`; then you decide what parameters you want to pass as query placeholders.


### PR DESCRIPTION
Removed the copy-pasted list of placeholders, fixing #55 

PS: I had to make two changes locally to get the site to build (and to get no hh_client errors) with 3.11.0-dev (rel):

1. Removed `hhvm/asio-utilities` from composer.json because [HHVM now includes them](https://github.com/facebook/hhvm/commit/0f1fbe65f4cbe1ff192f6137cf3416d2c388154c)
2. Unaliased Decl and inlined the full namespace: https://gist.github.com/daviddoran/1090ebea9bbaec6a3f15/revisions?diff=unified

<img width="1144" alt="asyncmysqlconnection queryf - updated examples" src="https://cloud.githubusercontent.com/assets/313983/11120990/477843be-894b-11e5-8dd4-3c829f7ce839.png">