### PR TITLE
Removed unnecessary backslashes in Collections examples.

### DIFF
--- a/guides/hack/23-collections/02-semantics-examples/converting-immutable.php.type-errors
+++ b/guides/hack/23-collections/02-semantics-examples/converting-immutable.php.type-errors
@@ -7,7 +7,7 @@ function foo_with_vector(ImmVector<int> $vec): void {
     // The type checker actually won't allow this, but you can run this
     // and catch the exception
     $vec[] = 5;
-  } catch (\InvalidOperationException $ex) {
+  } catch (InvalidOperationException $ex) {
     echo "Cannot modify immutable collection. Create copy first\n";
     $cp_vec = new Vector($vec);
     $cp_vec[] = 5;

--- a/guides/hack/23-collections/02-semantics-examples/list.php.type-errors
+++ b/guides/hack/23-collections/02-semantics-examples/list.php.type-errors
@@ -16,7 +16,7 @@ function run(): void {
     // Exception will be thrown since there is no 0 and 1 value in the Set
     // to serve as a key-like value
     list($x, $y) = $setB;
-  } catch (\OutOfBoundsException $ex) {
+  } catch (OutOfBoundsException $ex) {
     var_dump($ex->getMessage());
   }
   var_dump($v1);


### PR DESCRIPTION
If those backslashes were left there on purpose (like for future codegen etc.), then I'm sorry...