### PR TITLE
Add code example to Vector::splice API reference

### DIFF
--- a/guides/hack/99-api-examples/class.Vector/splice/001-basic-usage.md
+++ b/guides/hack/99-api-examples/class.Vector/splice/001-basic-usage.md
@@ -1,0 +1,1 @@
+The following example shows how to use `$offset` and `$len` together:

--- a/guides/hack/99-api-examples/class.Vector/splice/001-basic-usage.php
+++ b/guides/hack/99-api-examples/class.Vector/splice/001-basic-usage.php
@@ -1,0 +1,26 @@
+<?hh
+
+// Remove the element at index 2:
+$v = Vector {'red', 'green', 'blue', 'yellow'};
+$v->splice(2, 1);
+var_dump($v); // $v contains 'red', 'green', 'yellow'
+
+// Remove elements starting at index 2:
+$v = Vector {'red', 'green', 'blue', 'yellow'};
+$v->splice(2);
+var_dump($v); // $v contains 'red', 'green'
+
+// Remove three elements starting at index 0:
+$v = Vector {'red', 'green', 'blue', 'yellow'};
+$v->splice(0, 3);
+var_dump($v); // $v contains 'yellow'
+
+// Remove elements starting two positions from the end:
+$v = Vector {'red', 'green', 'blue', 'yellow'};
+$v->splice(-2);
+var_dump($v); // $v contains 'red', 'green
+
+// Remove elements starting at index 0 and stopping one position from the end:
+$v = Vector {'red', 'green', 'blue', 'yellow'};
+$v->splice(0, -1);
+var_dump($v); // $v contains 'yellow'

--- a/guides/hack/99-api-examples/class.Vector/splice/001-basic-usage.php.hhvm.expect
+++ b/guides/hack/99-api-examples/class.Vector/splice/001-basic-usage.php.hhvm.expect
@@ -1,0 +1,28 @@
+object(HH\Vector)#1 (3) {
+  [0]=>
+  string(3) "red"
+  [1]=>
+  string(5) "green"
+  [2]=>
+  string(6) "yellow"
+}
+object(HH\Vector)#2 (2) {
+  [0]=>
+  string(3) "red"
+  [1]=>
+  string(5) "green"
+}
+object(HH\Vector)#3 (1) {
+  [0]=>
+  string(6) "yellow"
+}
+object(HH\Vector)#4 (2) {
+  [0]=>
+  string(3) "red"
+  [1]=>
+  string(5) "green"
+}
+object(HH\Vector)#5 (1) {
+  [0]=>
+  string(6) "yellow"
+}

--- a/guides/hack/99-api-examples/class.Vector/splice/001-basic-usage.php.typechecker.expect
+++ b/guides/hack/99-api-examples/class.Vector/splice/001-basic-usage.php.typechecker.expect
@@ -1,0 +1,1 @@
+No errors!


### PR DESCRIPTION
### Test Plan

- `hh_client`
- Unit test: `hhvm ../hhvm/hphp/test/run --hhvm-binary-path /usr/local/bin/hhvm guides/hack/99-api-examples/class.Vector/splice/`
- http://127.0.0.1:8080/hack/reference/class/Vector/splice/

<img width="703" alt="vector-splice 2015-11-13 19-32-44" src="https://cloud.githubusercontent.com/assets/313983/11155580/48af8ae6-8a3e-11e5-9ff9-1c0fdc412634.png">