### PR TITLE
Make menu click targets full-width

### DIFF
--- a/public/js/APISideNav.js
+++ b/public/js/APISideNav.js
@@ -76,9 +76,9 @@ var DocNav = React.createClass({displayName: "DocNav",
         React.createElement("h4", {id: currentGroup}, 
           React.createElement("a", {className: 'navItem', href: groupHref}, currentGroup)
         ), 
-        React.createElement("ul", {className: 'subList'}, 
-          navGroupChildren
-        )
+        navGroupChildren.length > 0
+          ? React.createElement("ul", {className: 'subList'}, navGroupChildren)
+          : null
       )
     );
   },

--- a/public/js/SideNav.js
+++ b/public/js/SideNav.js
@@ -79,9 +79,9 @@ var DocNav = React.createClass({displayName: "DocNav",
         React.createElement("h4", {id: index},
           React.createElement("a", {className: 'navItem', href: groupHref}, formatTitle(index))
         ),
-        React.createElement("ul", {className: 'subList'},
-          navGroupChildren
-        )
+        navGroupChildren.length > 0
+          ? React.createElement("ul", {className: 'subList'}, navGroupChildren)
+          : null
       )
     );
   },

--- a/public/main.css
+++ b/public/main.css
@@ -566,16 +566,15 @@ h4 {
 .navWrapper .navList li h4 {
   font-family: "Whitney SSm A", "Whitney SSm B", Arial, Helvetica, sans-serif;
   font-size: 12px;
-  margin-bottom: 10px;
   text-transform: uppercase;
 }
 .navWrapper .navList li h4 a {
   color: #fd8724;
-  padding-left: 30px;
+  padding: 10px 0 10px 30px;
 }
 
 .navWrapper .subList {
-  margin-bottom: 30px;
+  margin-bottom: 20px;
 }
 
 .navList {
@@ -910,7 +909,7 @@ h4 {
     padding: 20px 0;
   }
 
-  .navList.apiNavList .subListItem h5::before {
+  .navList.apiNavList .subListItem h5 a::before {
     top: 0px;
   }
 }
@@ -933,15 +932,15 @@ h4 {
     max-width: 1200px;
   }
 
-  .subListItem h5::before {
+  .subListItem h5 a::before {
     top: 12px;
   }
 
-  .apiNavList .subListItem h5::before {
+  .apiNavList .subListItem h5 a::before {
     top: 10px;
   }
 
-  .navList.apiNavList .subListItem h5::before {
+  .navList.apiNavList .subListItem h5 a::before {
     top: 2px;
   }
 }

--- a/public/main.css
+++ b/public/main.css
@@ -555,6 +555,12 @@ h4 {
 
 .navWrapper .navList li a {
   color: #B0B0B0;
+  display: block;
+}
+
+.navWrapper .navList li a:hover {
+  background-color: #DADADA;
+  color: #303030;
 }
 
 .navWrapper .navList li h4 {
@@ -565,6 +571,7 @@ h4 {
 }
 .navWrapper .navList li h4 a {
   color: #fd8724;
+  padding-left: 30px;
 }
 
 .navWrapper .subList {
@@ -583,40 +590,40 @@ h4 {
 
 .navWrapper .navList.apiNavList .subListItem h5 {
   line-height: 0.7em;
-  margin-bottom: 15px;
 }
 
 .navWrapper .navList.apiNavList .subListItem h5 a {
   font-family: "Whitney SSm A", "Whitney SSm B", Arial, Helvetica, sans-serif;
   font-size: 12px;
   font-weight: 400;
+  padding: 7.5px 30px;
   word-wrap: break-word;
 }
 
 .navWrapper .navList.apiNavList .secondLevelListItem h6 {
   line-height: 0.7em;
-  margin-bottom: 15px;
-  padding-left: 15px;
 }
 
 .navWrapper .navList.apiNavList .secondLevelListItem h6 a {
   font-family: "Whitney SSm A", "Whitney SSm B", Arial, Helvetica, sans-serif;
   font-size: 12px;
   font-weight: 400;
+  padding: 7.5px 0 7.5px 45px;
   word-wrap: break-word;
 }
 
-.navWrapper .navList .subListItem h5 {
+.navWrapper .navList .subListItem h5 a {
   position: relative;
+  padding-left: 30px;
 }
 
-.subListItem h5::before {
+.subListItem h5 a::before {
   border-color: transparent transparent transparent transparent;
   border-style: solid;
   border-width: 5px 0 5px 8.7px;
   content: "";
   height: 0;
-  left: -12px;
+  left: 12px;
   position: absolute;
   top: 8px;
   -webkit-transition: border-color 0.5s;
@@ -625,7 +632,11 @@ h4 {
   width: 0;
 }
 
-.subListItem:hover h5::before {
+.apiNavList .subListItem h5 a::before {
+  top: 7.5px;
+}
+
+.subListItem:hover h5 a::before {
   border-color: transparent transparent transparent #505050;
 }
 
@@ -638,7 +649,7 @@ h4 {
   color: #303030;
 }
 
-.subListItem.itemActive h5::before {
+.subListItem.itemActive h5 a::before {
   border-color: transparent transparent transparent #fd8724;
 }
 
@@ -896,7 +907,7 @@ h4 {
     height: 100%;
     overflow-x: hidden;
     overflow-y: scroll;
-    padding: 20px 30px;
+    padding: 20px 0;
   }
 
   .navList.apiNavList .subListItem h5::before {

--- a/public/main.css
+++ b/public/main.css
@@ -570,7 +570,8 @@ h4 {
 }
 .navWrapper .navList li h4 a {
   color: #fd8724;
-  padding: 10px 0 10px 30px;
+  padding-bottom: 10px;
+  padding-top: 10px;
 }
 
 .navWrapper .subList {
@@ -595,7 +596,8 @@ h4 {
   font-family: "Whitney SSm A", "Whitney SSm B", Arial, Helvetica, sans-serif;
   font-size: 12px;
   font-weight: 400;
-  padding: 7.5px 30px;
+  padding-bottom: 7.5px;
+  padding-top: 7.5px;
   word-wrap: break-word;
 }
 
@@ -607,13 +609,13 @@ h4 {
   font-family: "Whitney SSm A", "Whitney SSm B", Arial, Helvetica, sans-serif;
   font-size: 12px;
   font-weight: 400;
-  padding: 7.5px 0 7.5px 45px;
+  padding-bottom: 7.5px;
+  padding-top: 7.5px;
   word-wrap: break-word;
 }
 
 .navWrapper .navList .subListItem h5 a {
   position: relative;
-  padding-left: 30px;
 }
 
 .subListItem h5 a::before {
@@ -869,6 +871,10 @@ h4 {
     width: 50%;
   }
 
+  .subListItem h5 a::before {
+    left: -12px;
+  }
+
   .widthWrapper {
     margin: 0 10px;
   }
@@ -909,8 +915,20 @@ h4 {
     padding: 20px 0;
   }
 
+  .navWrapper .navList li h4 a {
+    padding-left: 30px;
+  }
+
+  .navWrapper .navList .subListItem h5 a {
+    padding-left: 30px;
+  }
+
+  .navWrapper .navList.apiNavList .secondLevelListItem h6 a {
+    padding-left: 45px;
+  }
+
   .navList.apiNavList .subListItem h5 a::before {
-    top: 0px;
+    top: 7.5px;
   }
 }
 @media only screen and (min-width: 1200px) {
@@ -938,10 +956,6 @@ h4 {
 
   .apiNavList .subListItem h5 a::before {
     top: 10px;
-  }
-
-  .navList.apiNavList .subListItem h5 a::before {
-    top: 2px;
   }
 }
 


### PR DESCRIPTION
To me the existing menu styling isn't the user-friendliest for three reasons:

1. Only the text of each item is clickable so "at" and "add" have tiny click targets
2. The grey arrows appear when hovering the h5/h6 and not the click targets (giving the impression that clicking will select that item)
3. The background color of the items doesn't change

Before (note the small click targets and the misleading arrows):

![menu - before](https://cloud.githubusercontent.com/assets/313983/11168697/da21f7fc-8b92-11e5-99bc-06a979cd1031.gif)

After (all click targets are full-width and the arrows only appear when the item is clickable):

![menu - after](https://cloud.githubusercontent.com/assets/313983/11168698/e1e97c30-8b92-11e5-8ab6-2440f889fc74.gif)
