### PR TITLE
Use backticks for <ul> / <li> to prevent them being interpreted as HTML

### DIFF
--- a/guides/hack/24-XHP/06-guidelines.md
+++ b/guides/hack/24-XHP/06-guidelines.md
@@ -18,7 +18,7 @@ This validation is on by default. You can turn it off by running the following c
 
 ## Use Contexts to Access Higher Level Information
 
-If you have a parent object, and you want to give information to some object further down the UI tree (e.g., <ul> to <li>), you can set a context for those lower objects and the lower objects can retrieve them. You use `setContext()` and `getContext()`
+If you have a parent object, and you want to give information to some object further down the UI tree (e.g., `<ul>` to `<li>`), you can set a context for those lower objects and the lower objects can retrieve them. You use `setContext()` and `getContext()`
 
 @@ guidelines-examples/context.php @@
 


### PR DESCRIPTION
- http://beta.docs.hhvm.com/hack/XHP/guidelines#use-contexts-to-access-higher-level-information
- http://127.0.0.1:8080/hack/XHP/guidelines#use-contexts-to-access-higher-level-information

Before:
<img width="1062" alt="xhp guidelines 2015-11-17 14-14-32" src="https://cloud.githubusercontent.com/assets/313983/11213865/4b7e892a-8d36-11e5-9ce9-79118f0a6942.png">


After:
<img width="1093" alt="xhp guidelines 2015-11-17 14-15-57" src="https://cloud.githubusercontent.com/assets/313983/11213864/4b771dd4-8d36-11e5-9aed-3bab668f53db.png">