### PR TITLE
Fix small typo (unnecessary parenthesis) in "Hack Tools: Introduction"

### DIFF
--- a/guides/hack/02-tools/01-introduction.md
+++ b/guides/hack/02-tools/01-introduction.md
@@ -1,6 +1,6 @@
 # Other Hack Tools
 
-In addition to the language itself, Hack provides programmers a wide set of tools for. Using [`hh_client`](../typechecking/options.md)) for typechecking and inspecting your codebase is most likely to be your most used tool. However, there are other tools used to help you make the most out of Hack
+In addition to the language itself, Hack provides programmers a wide set of tools for. Using [`hh_client`](../typechecking/options.md) for typechecking and inspecting your codebase is most likely to be your most used tool. However, there are other tools used to help you make the most out of Hack
 
 * adding type annotations to your code and quick type checking ([`hh_server`](./hhserver.md))
 * migrating PHP code to Hack ([`hackificator`](./hackificator.md))


### PR DESCRIPTION
Before:

<img width="464" alt="tools introduction 2015-11-17 16-22-13" src="https://cloud.githubusercontent.com/assets/313983/11217321/a0f21ab4-8d47-11e5-8454-7dadd206d9e5.png">

After:

<img width="436" alt="tools introduction 2015-11-17 16-22-22" src="https://cloud.githubusercontent.com/assets/313983/11217322/a0f3891c-8d47-11e5-9097-c2d614a461b8.png">