### PR TITLE
Fix a few small typos / formatting issues in Hack "Types" section

### DIFF
--- a/guides/hack/20-types/03-annotations.md
+++ b/guides/hack/20-types/03-annotations.md
@@ -43,17 +43,21 @@ public int $x;
 A class in Hack can be marked both `abstract` and `final`. This means the class can only have static methods and properties, and no constructor. A property is annotated with `static`, in addition to the data type.
 
 ```
-abstrct final class X {
+abstract final class X {
   public static array<int> $a = array();
 }
 ```
 
 ### Abstract class constants
 
-In addition to typing properties with their data type, you can also declare constants abstract in an abstract class
+In addition to typing properties with their data type, you can also declare constants abstract in an abstract class or interface.
 
 ```
 interface I {
+  abstract const int MY_CONST;
+}
+
+abstract class Y {
   abstract const int MY_CONST;
 }
 ```

--- a/guides/hack/20-types/04-inference.md
+++ b/guides/hack/20-types/04-inference.md
@@ -14,7 +14,7 @@ Local variables are not type annotated. Their types are inferred based on the fl
 
 The above example showed a case where a variable was assigned to an `int ` in both branches of the `if/else`. This makes it easy for the typechecker to determine that a variable can and only will be an `int` when it encounters the `return`.
 
-However what happens if instead of assigning a variable to the same type in both branches of a conditional, you decide to assign it to a different type in each branch. 
+However what happens if instead of assigning a variable to the same type in both branches of a conditional, you decide to assign it to a different type in each branch?
 
 @@ inference-examples/unresolved.php.type-errors @@
 

--- a/guides/hack/20-types/06-refining.md
+++ b/guides/hack/20-types/06-refining.md
@@ -3,14 +3,16 @@
 Suppose you want to take a given type and refine (upcast) that type to another type. Hack allows this through using the following in control-flow situations:
 
 - checking for `null`
-- type-querying (e.g., via `is_float()``)
+- type-querying (e.g., via `is_float()`)
 - using `instanceof`
 
 ## Invariant
 
 There is also a special function:
 
-- `invariant(<bool expression of fact>, "Message if not")`
+```
+invariant(<bool expression of fact>, "Message if not")
+```
 
 that can be used outside control-flow situation. It is essentially an assert to the typechecker that what you claim in the boolean statement is fact and true.
 
@@ -18,13 +20,13 @@ In any of the refining scenarios below, you can use `invariant()` as opposed to 
 
 ## Nullable to Non-Nullable
 
-Remember that a nullable type allows the value of a variable to be of its type or `null`. There are times when you want to utilize only the non-`null` part of that type. You can refine the nullable type with null checks
+Remember that a nullable type allows the value of a variable to be of its type or `null`. There are times when you want to utilize only the non-`null` part of that type. You can refine the nullable type with null checks.
 
 @@ refining-examples/nullable.php @@
 
 ## Mixed to Primitive
 
-Remember that `mixed` represent any annotatable type (except a nullable type). `mixed` can be refined into a more specific primitive type through the use of built-in type querying functions such as [`is_int()`](http://php.net/manual/en/function.is-int.php), [`is_float()`](http://php.net/manual/en/function.is-float.php), [`is_string()`](http://php.net/manual/en/function.is-string.php), etc.
+Remember that `mixed` represents any annotatable type (except a nullable type). `mixed` can be refined into a more specific primitive type through the use of built-in type querying functions such as [`is_int()`](http://php.net/manual/en/function.is-int.php), [`is_float()`](http://php.net/manual/en/function.is-float.php), [`is_string()`](http://php.net/manual/en/function.is-string.php), etc.
 
 @@ refining-examples/mixed.php @@
 

--- a/guides/hack/20-types/07-runtime.md
+++ b/guides/hack/20-types/07-runtime.md
@@ -8,8 +8,8 @@ However, there is some support for runtime type checking in HHVM, but its enforc
 
 - HHVM ignores property annotations.
 - HHVM supports parameter and return type annotations; generally, if you violate the agreement, a catchable fatal error will be thrown. However there are exceptions:
--- `void` is not enforced at runtime; i.e., you can return a value from a `void` function at runtime
--- [Generics](../generics/introduction.md) are enforced as if they did not have type parameters.
--- [Shapes](../shapes/introduction.md) and [tuples](type-system.md#tuples) are only enforced as if they were an `array()`. The inner types of each are not enforced.
--- [Enums](../enums/introduction.md) are enforced only at the underlying type level. HHVM does not check for valid enum values
--- If you specify the [soft-type hint operator `@`](advanced-rules.md#Soft Type Hints) before an annotation, a warning would be thrown in the case where a catchable fatal would have been.
+  - `void` is not enforced at runtime; i.e., you can return a value from a `void` function at runtime
+  - [Generics](../generics/introduction.md) are enforced as if they did not have type parameters.
+  - [Shapes](../shapes/introduction.md) and [tuples](type-system.md#tuples) are only enforced as if they were an `array()`. The inner types of each are not enforced.
+  - [Enums](../enums/introduction.md) are enforced only at the underlying type level. HHVM does not check for valid enum values.
+  - If you specify the [soft-type hint operator `@`](advanced-rules.md#Soft Type Hints) before an annotation, a warning would be thrown in the case where a catchable fatal would have been.

--- a/guides/hack/20-types/08-advanced-rules.md
+++ b/guides/hack/20-types/08-advanced-rules.md
@@ -31,10 +31,9 @@ function foo(<any explicit arguments>, ...) // use func_get_args() to get the ar
 function foo(<any explicit arguments>, int ...$args) // $args is a list of int arguments
 ```
 
-The second method is preferred since it is more expressive with the typehint. However, and **this is important**, HHVM does not support variadic parameters *with typehints*
+The second method is preferred since it is more expressive with the typehint. However, and **this is important**, HHVM does not support variadic parameters *with typehints*.
 
-So, use the second method, but you will have to leave off the typehint and have your code in [partial mode](../typechecker/modes.md#partial-mode) or use `HH_FIXME` or `UNSAFE` in [strict mode](../typechecker/modes.md#strict-mode) in order to make both the
-typechecker and HHVM happy.
+So, use the second method, but you will have to leave off the typehint and have your code in [partial mode](../typechecker/modes.md#partial-mode) or use `HH_FIXME` or `UNSAFE` in [strict mode](../typechecker/modes.md#strict-mode) in order to make both the typechecker and HHVM happy.
 
 @@ advanced-rules-examples/variadic.php @@
 


### PR DESCRIPTION
- Fix typo in "abstract final classes" code example
- Add example of an `abstract const` in an abstract class
- Add question mark to rhetorical question in "Inference" section
- Fix some formatting typos in "Refining" section
- Fix list formatting in "Runtime" section
- Fix missing period and extra hard linebreak in "Advanced Rules" section

<img width="1111" alt="types annotations 2015-11-17 16-54-58" src="https://cloud.githubusercontent.com/assets/313983/11218469/1ffb75bc-8d4d-11e5-9de1-940366e28c75.png">
