### PR TITLE
Fix a few typos and formatting issues in "Hack: Async" section

### DIFF
--- a/guides/hack/22-async/01-introduction-examples/limitations.php
+++ b/guides/hack/22-async/01-introduction-examples/limitations.php
@@ -29,7 +29,7 @@ async function main(): Awaitable<void> {
   await \HH\Asio\v([
     do_cpu_work(),
     do_sleep(),
- ]);
+  ]);
   print("End of main()\n");
 }
 

--- a/guides/hack/22-async/02-awaitables-examples/single-awaitable.php
+++ b/guides/hack/22-async/02-awaitables-examples/single-awaitable.php
@@ -7,7 +7,7 @@ async function foo(): Awaitable<int> {
 }
 
 async function single_awaitable_main(): Awaitable<void> {
-  $aw = foo(); // awaitable of type Awatiable<int>
+  $aw = foo(); // awaitable of type Awaitable<int>
   $result = await $aw; // an int after $aw completes
   var_dump($result);
 }

--- a/guides/hack/22-async/02-awaitables.md
+++ b/guides/hack/22-async/02-awaitables.md
@@ -10,7 +10,7 @@ The type returned from an async function is `Awatiable<T>`, where `T` is the fin
 
 ```
 async function foo(): Awaitable<int> {...}
-:
+
 $x = foo(); // $x will be an Awaitable<int>
 $x = await foo(); // $x will be an int
 ```
@@ -42,7 +42,7 @@ Here we are using one of the two built-in async helper functions in the `HH\Asio
 
 Sometimes you want to get a result out of an awaitable when the function you are in **is not** `async`. For this there is `HH\Asio\join()`. Pass an `Awaitable` to `join()`.
 
-Note: that global function calls (e.g., `main()`) require a join if that function is `async`). For example:
+Note: that global function calls (e.g., `main()`) require a join if that function is `async`. For example:
 
 ```
 HH\Asio\join(main());
@@ -50,4 +50,4 @@ HH\Asio\join(main());
 
 @@ awaitables-examples/join.php @@
 
-You should not call `join()` inside an `async` function. This would defeat the purpose of `async` as the the awaitable and any dependencies will run to completion synchronously, stopping any other awaitables in their tracks from running. Just `await` in an `async` function.
+You should not call `join()` inside an `async` function. This would defeat the purpose of `async` as the awaitable and any dependencies will run to completion synchronously, stopping any other awaitables in their tracks from running. Just `await` in an `async` function.

--- a/guides/hack/22-async/03-exceptions.md
+++ b/guides/hack/22-async/03-exceptions.md
@@ -6,7 +6,7 @@ In general, async follows this pattern:
 * get an awaitable back
 * `await` the awaitable to get a result
 
-However, sometimes an async function can throw an exception. The good news is that the same exception object that would be thrown in the non-async version of the code is the same that will be returned when you `await` the awaitable.
+However, sometimes an async function can throw an exception. The good news is that the same exception object that would be thrown in the non-async version of the code will be returned when you `await` the awaitable.
 
 @@ exceptions-examples/basic-exception.php @@
 
@@ -14,17 +14,16 @@ Using the basic utility functions [`v()`](utility-functions.md) or [`m()`](utili
 
 @@ exceptions-examples/multiple-awaitable-exception.php @@
 
-To get around this, and get the successful results as well, we can use the `asio-utilities` function called [`HH\Asio\wrap()`](link to wrap). It takes an awaitable and returns the expected result or the exception if one was thrown. The exception is gives back is of the type `ResultOrExceptionWrapper`.
+To get around this, and get the successful results as well, we can use the `asio-utilities` function called [`HH\Asio\wrap()`](utility-functions.md). It takes an awaitable and returns the expected result or the exception if one was thrown. The exception it gives back is of the type `ResultOrExceptionWrapper`.
 
 ```
 namespace HH\Asio {
-
-interface ResultOrExceptionWrapper<T> {
-  public function isSucceeded(): bool;
-  public function isFailed(): bool;
-  public function getResult(): T;
-  public function getException(): \Exception;
-}
+  interface ResultOrExceptionWrapper<T> {
+    public function isSucceeded(): bool;
+    public function isFailed(): bool;
+    public function getResult(): T;
+    public function getException(): \Exception;
+  }
 }
 ```
 
@@ -32,6 +31,6 @@ Taking the example above and using this mechanism:
 
 @@ exceptions-examples/wrapping-exceptions.php @@
 
-And here is the output:
+Here is the output:
 
 @@ exceptions-examples/wrapping-exceptions.php.hhvm.expectf @@

--- a/guides/hack/22-async/04-blocks-examples/syntactic-sugar.php
+++ b/guides/hack/22-async/04-blocks-examples/syntactic-sugar.php
@@ -19,7 +19,7 @@ async function gen_call<Tv>((function (): Awaitable<Tv>) $gen): Awaitable<Tv> {
 }
 
 async function use_async_lambda(): Awaitable<void> {
-  // To use an async lambda with no arguments, you would to have a helper
+  // To use an async lambda with no arguments, you would need to have a helper
   // function to return an actual Awaitable for you.
   $x = await gen_call(
     async () ==> {

--- a/guides/hack/22-async/05-utility-functions.md
+++ b/guides/hack/22-async/05-utility-functions.md
@@ -5,7 +5,7 @@ Async can be used effectively with the built-in infrastructure in HHVM. This inf
 * `async`, `await`, `Awaitable`
 * `HH\Asio\v()`, `HH\Asio\m()`
 
-However, there are cases when you want to convert some collection of values to awaitables or you want to filter some awaitables out of a collection of awaitables. These type of scenarios come up when you are creating multiple awaitables to await in parallel. 
+However, there are cases when you want to convert some collection of values to awaitables or you want to filter some awaitables out of a collection of awaitables. These types of scenarios come up when you are creating multiple awaitables to await in parallel. 
 
 You can use functions like `array_filter()`, or the methods on the Hack collection classes, etc. to do this mapping and filtering. However, there is a set of utility functions, specifically created for async, that will make your code more streamlined. 
 
@@ -62,15 +62,12 @@ Let's say you have the following:
 
 ```
 function baz(): Awaitable<(X, int)> {
-:
-:
   list ($a, $b) = 
     await \HH\Asio\v(array(
       returns_an_X($foo), 
       returns_an_int($bar),
     ));
-:
-:
+
   return tuple($a, $b);
 }
 ```
@@ -83,7 +80,7 @@ example.php:60:12,44: Invalid return type (Typing[4110])
   example.php:25:61,63: It is incompatible with an int
 ```
 
-That is because `HH\Asio\v()` takes an `Traversable<Awaitable<T>>` and returns an `Awaitable<Vector<T>>`. There is no `T` that can be both an `X` and an `int`. So the type checker basically throws its hands up and creates a some sort of union type for `T` that tries to represent both of those.
+That is because `HH\Asio\v()` takes a `Traversable<Awaitable<T>>` and returns an `Awaitable<Vector<T>>`. There is no `T` that can be both an `X` and an `int`. So the type checker basically throws its hands up and creates some sort of union type for `T` that tries to represent both of those.
 
 However, when you want to return the `tuple($a, $b)`, `$a` is an `X`, `b` is an `int`, but the type-checker doesn't realize that since it thinks these should be the hybrid union type it created above.
 

--- a/guides/hack/22-async/07-guidelines.md
+++ b/guides/hack/22-async/07-guidelines.md
@@ -4,7 +4,7 @@ It might be tempting to just throw `async`, `await` and `Awaitable` on all your 
 
 ## Be Liberal, but Careful, with Async
 
-If you are struggling as to whether your code should be async or not, you can generally start with the answer //yes// and find a reason to say //no//. For example, a simple //hello world// program can be made async with no performance penalty. You will likely not get any gain, but you will not get any loss -- and it is setup for any future changes that may require async.
+If you are struggling as to whether your code should be async or not, you can generally start with the answer *yes* and find a reason to say *no*. For example, a simple *hello world* program can be made async with no performance penalty. You will likely not get any gain, but you will not get any loss -- and it is setup for any future changes that may require async.
 
 These two programs are, for all intents and purposes, equivalent.
 
@@ -50,7 +50,7 @@ Possibly the most important aspect in learning how to structure async code is un
 2. Put each bundle of parallel chains into its own `async` function.
 3. Repeat to see if there are further reductions.
 
-Let's say we are getting blog posts of an author. This would involve the following of steps:
+Let's say we are getting blog posts of an author. This would involve the following steps:
 
 1. Get the post ids for an author.
 2. Get the post text for each post id.
@@ -99,7 +99,7 @@ Basically, don't depend on the order of output between runs of the same code. i.
 
 Given that async is commonly used in operations that are time-consuming, memoizing (i.e., caching) the result of an async call can definitely be worthwhile.
 
-The [`<<__Memoize>>`](../attributes/special.md#__memoize) attribute does the right thing. So, if you can, use that. However, if you are needing explicit control of the memoization, make sure you only //memoize the awaitable//.
+The [`<<__Memoize>>`](../attributes/special.md#__memoize) attribute does the right thing. So, if you can, use that. However, if you need explicit control of the memoization, make sure you *memoize the awaitable* and not the result of awaiting it.
 
 @@ guidelines-examples/memoize-result.php @@
 
@@ -116,7 +116,7 @@ awaits `time_consuming()` again. Now the time-consuming operation will be done t
 
 If `time_consuming()` has side effects (e.g. a database write), then this could end up being a serious bug. Even if there are no side effects, it’s still a bug; the time-consuming operation is being done multiple times when it only needs to be done once.
 
-Instead, memoize the awaitable
+Instead, memoize the awaitable:
 
 @@ guidelines-examples/memoize-awaitable.php @@
 


### PR DESCRIPTION
Test Plan:

- `hh_client`
- `hhvm bin/build.php` and browsed the affected pages