### PR TITLE
Fix styling of code blocks in lists

### DIFF
--- a/sass/innerContent.scss
+++ b/sass/innerContent.scss
@@ -31,6 +31,10 @@
     max-width: 100%;
   }
 
+  li > code {
+    @include codeemph;
+  }
+
   ol {
     list-style: decimal inside;
     margin: 0.5em 0 2em;
@@ -41,10 +45,7 @@
     padding-bottom: 1.5em;
 
     & > code {
-      background: $lightergreen;
-      border-radius: 2px;
-      color: $green;
-      padding: 1px 3px;
+      @include codeemph;
     }
   }
 

--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -27,6 +27,13 @@ $darkblue: #113790;
   line-height: 1.4em;
 }
 
+@mixin codeemph {
+  background: $lightergreen;
+  border-radius: 2px;
+  color: $green;
+  padding: 1px 3px;
+}
+
 @mixin headerfade {
   opacity: 0.3;
   @include transition(opacity 0.3s);


### PR DESCRIPTION
The old rule here is pretty specific, `p > code` to get the green
background. At first glance, it seems overly specific, but we don't want
to give code inside links green backgrounds. So let's just add a second
rule that `li > code` also gets the green background, which fixes all
the cases I can see.