### PR TITLE
Fix XHP introduction link

### DIFF
--- a/guides/hack/60-unsupported/04-html.md
+++ b/guides/hack/60-unsupported/04-html.md
@@ -16,4 +16,4 @@ In Hack, `<?hh` must always be the first 4 characters seen.
 
 ## Use XHP
 
-If you really want to mix HTML-like elements with your Hack code, [XHP](xhp/introduction.md) was made especially for that. And, it is typecheckable.
+If you really want to mix HTML-like elements with your Hack code, [XHP](../XHP/introduction.md) was made especially for that. And, it is typecheckable.


### PR DESCRIPTION
The XHP link previously linked to `/hack/unsupported/xhp/introduction` but it should link to `/hack/XHP/introduction`.