### PR TITLE
Allow exact redirect to special attributes on /j search

### DIFF
--- a/src/build/UnifiedAPIIndexBuildStep.php
+++ b/src/build/UnifiedAPIIndexBuildStep.php
@@ -12,6 +12,7 @@ final class UnifiedAPIIndexBuildStep extends BuildStep {
 
     $defs = new Map($this->getPHPAPILinks());
     $defs->setAll($this->getHackAPILinks());
+    $defs->setAll($this->getSpecialAttributeLinks());
 
     file_put_contents(
       BuildPaths::UNIFIED_INDEX_JSON,
@@ -75,5 +76,20 @@ final class UnifiedAPIIndexBuildStep extends BuildStep {
     }
 
     return $out->toImmMap();
+  }
+
+  // For special attributes that don't exist in our API reference, but can be
+  // used in APIs, manually add special /j/search capability
+  private function getSpecialAttributeLinks(): ImmMap<string, string> {
+    return ImmMap {
+      '__memoize' => '/hack/attributes/special#__memoize',
+      '__consistentconstruct' =>
+        '/hack/attributes/special#__consistentconstruct',
+      '__override' => '/hack/attributes/special#__override',
+      '__deprecated' => '/hack/attributes/special#__deprecated',
+      '__mockclass' => '/hack/attributes/special#__mockclass',
+      '__isfoldable' => '/hack/attributes/special#__isfoldable',
+      '__native' => '/hack/attributes/special#__native',
+    };
   }
 }

--- a/tests/OpenSearchTest.php
+++ b/tests/OpenSearchTest.php
@@ -47,6 +47,10 @@ final class OpenSearchTest extends \PHPUnit_Framework_TestCase {
         '=>foobar',
         '/search?term=%3D%3Efoobar',
       ),
+      'Special attribute' => tuple(
+        '__memoize',
+        '/hack/attributes/special#__memoize',
+      ),
     ];
   }
 


### PR DESCRIPTION
I figure we can special case these. Could do the same with the Enum
fuctions, if we wanted; maybe even the XHP method table too. But this
was the easiest low hanging fruit, and probably the more searched anyway.

Fixes #220