### PR TITLE
Fix typo

### DIFF
--- a/guides/hack/60-unsupported/06-others.md
+++ b/guides/hack/60-unsupported/06-others.md
@@ -19,7 +19,7 @@ The typechecker will also raise undefined variable errors for any locals that
 
 @@ others-examples/varvars.php.type-errors @@
 
-There is no way to do type inference in a case like this. The typechecker can't know that what we meant by assigning `x` to `$val` was that we were going to use that `x` has a variable later on.
+There is no way to do type inference in a case like this. The typechecker can't know that what we meant by assigning `x` to `$val` was that we were going to use that `x` as a variable later on.
 
 ## Dynamic Properties
 


### PR DESCRIPTION
s/... use `x` has a variable/... use `x` as a variable/g