### PR TITLE
fixed index values in comments

### DIFF
--- a/guides/hack/23-collections/01-introduction-examples/array-typecheck.php
+++ b/guides/hack/23-collections/01-introduction-examples/array-typecheck.php
@@ -11,7 +11,7 @@ function array_as_map(array<int, int> $arr): int {
 
 function run(): void {
   $v = array(100, 200, 300, 400);
-  $v[] = 500; // index 5, value 500
+  $v[] = 500; // index 4, value 500
   var_dump($v);
   var_dump(array_as_map($v));
 }

--- a/guides/hack/23-collections/01-introduction-examples/array-typecheck.php
+++ b/guides/hack/23-collections/01-introduction-examples/array-typecheck.php
@@ -11,7 +11,7 @@ function array_as_map(array<int, int> $arr): int {
 
 function run(): void {
   $v = array(100, 200, 300, 400);
-  $v[] = 500; // index 4, value 500
+  $v[] = 500; // element 5, value 500
   var_dump($v);
   var_dump(array_as_map($v));
 }

--- a/guides/hack/23-collections/01-introduction-examples/array.php
+++ b/guides/hack/23-collections/01-introduction-examples/array.php
@@ -16,7 +16,7 @@ function array_as_vector(array<int> $arr): int {
 
 function run(): void {
   $v = array(100, 200, 300, 400);
-  $v[] = 500; // index 4, value 500
+  $v[] = 500; // element 5, value 500
   var_dump($v);
   var_dump(array_as_vector($v));
 

--- a/guides/hack/23-collections/01-introduction-examples/array.php
+++ b/guides/hack/23-collections/01-introduction-examples/array.php
@@ -16,7 +16,7 @@ function array_as_vector(array<int> $arr): int {
 
 function run(): void {
   $v = array(100, 200, 300, 400);
-  $v[] = 500; // index 5, value 500
+  $v[] = 500; // index 4, value 500
   var_dump($v);
   var_dump(array_as_vector($v));
 

--- a/guides/hack/23-collections/01-introduction-examples/map-typecheck.php.type-errors
+++ b/guides/hack/23-collections/01-introduction-examples/map-typecheck.php.type-errors
@@ -10,7 +10,7 @@ function array_as_map(Map<int, int> $arr): int {
 
 function run(): void {
   $v = Vector { 100, 200, 300, 400 };
-  $v[] = 500; // index 5, value 500
+  $v[] = 500; // index 4, value 500
   var_dump($v);
   // The call to array_as_map will not typecheck because you are trying to pass
   // a Vector into a function expecting a Map. You will also get a runtime

--- a/guides/hack/23-collections/01-introduction-examples/map-typecheck.php.type-errors
+++ b/guides/hack/23-collections/01-introduction-examples/map-typecheck.php.type-errors
@@ -10,7 +10,7 @@ function array_as_map(Map<int, int> $arr): int {
 
 function run(): void {
   $v = Vector { 100, 200, 300, 400 };
-  $v[] = 500; // index 4, value 500
+  $v[] = 500; // element 5, value 500
   var_dump($v);
   // The call to array_as_map will not typecheck because you are trying to pass
   // a Vector into a function expecting a Map. You will also get a runtime


### PR DESCRIPTION
Array indexing starts at zero. Minor mistakes there. Orvid King guessed a better labeling for that one so I've changed ´index´ to ´element´.

Bye~