### PR TITLE
Use previously unused function

### DIFF
--- a/guides/hack/40-generics/03-subtypes-examples/intuitive.php
+++ b/guides/hack/40-generics/03-subtypes-examples/intuitive.php
@@ -11,8 +11,8 @@ function get_int(): int {
 }
 
 function run(): void {
-  $num1 = rand();
-  $num2 = rand();
+  $num1 = get_int();
+  $num2 = get_int();
   echo_add($num1, $num2); // int is a subtype of num
 }
 


### PR DESCRIPTION
Prior to this patch `get_int()` was unused. I think the intention in this example was to use that function to get the random numbers instead of calling `rand()` directly but feel free to close if that's not the case.