### PR TITLE
Use codegen parameter objects

### DIFF
--- a/src/build/RoutingCodegenBuildStep.php
+++ b/src/build/RoutingCodegenBuildStep.php
@@ -2,7 +2,9 @@
 
 namespace HHVM\UserDocumentation;
 
+use Facebook\HackCodegen as hcg;
 use FredEmmott\HackRouter\Codegen;
+use FredEmmott\TypeAssert\TypeAssert;
 
 final class RoutingCodegenBuildStep extends BuildStep {
   public function buildAll(): void {
@@ -12,6 +14,7 @@ final class RoutingCodegenBuildStep extends BuildStep {
       shape(
         'controller_base' => \RoutableController::class,
         'router' => self::getRouterConfig(),
+        'request_parameters' => self::getRequestParametersConfig(),
       ),
     )->build();
   }
@@ -21,6 +24,51 @@ final class RoutingCodegenBuildStep extends BuildStep {
       'file' => LocalConfig::ROOT.'/src/site/RouterCodegenBase.php',
       'class' => 'RouterCodegenBase',
       'abstract' => true,
+    );
+  }
+
+  private static function getRequestParametersConfig(
+  ): Codegen::TRequestParametersCodegenConfig {
+    $root = LocalConfig::ROOT.'/src/site/controllers/codegen/';
+    return shape(
+      'get_parameters' => $class ==> {
+        $class = TypeAssert::isClassnameOf(\WebController::class, $class);
+        $spec = $class::getParametersSpec();
+        $out = Vector {};
+        foreach ($spec['required'] as $p) {
+          $out[] = shape('spec' => $p, 'optional' => false);
+        }
+        foreach ($spec['optional'] as $p) {
+          $out[] = shape('spec' => $p, 'optional' => true);
+        }
+        return $out->immutable();
+      },
+      'trait' => shape(
+        'requireExtends' => ImmSet {
+          \WebController::class,
+        },
+        'methodName' => 'getParameters',
+        'methodImplementation' => $spec ==>
+          hcg\hack_builder()
+            ->addAssignment(
+              '$params',
+              '$this->getParameters_PRIVATE_IMPL()',
+            )
+            ->addReturn(
+              'new %s($params)',
+              $spec['class']['name'],
+            )
+            ->getCode(),
+      ),
+      'output' => $classname ==> shape(
+        'file' => $root.$classname.'Parameters.php',
+        'class' => shape(
+          'name' => $classname.'Parameters',
+        ),
+        'trait' => shape(
+          'name' => $classname.'ParametersTrait',
+        ),
+      ),
     );
   }
 }

--- a/src/site/RouterCodegenBase.php
+++ b/src/site/RouterCodegenBase.php
@@ -5,7 +5,7 @@
  * To re-generate this file run /var/www/bin/build.php
  *
  *
- * @generated SignedSource<<4b3584e75a767e12b22ee296e869dc91>>
+ * @generated SignedSource<<2fc55122b2d8a14ef0a8ce45b3724a41>>
  */
 
 abstract class RouterCodegenBase
@@ -16,22 +16,22 @@ abstract class RouterCodegenBase
   ): ImmMap<\FredEmmott\HackRouter\HttpMethod, ImmMap<string, classname<\RoutableController>>> {
     $get = ImmMap {
       '/' => \HomePageController::class,
-      '/j/{keyword}' => \JumpController::class,
-      '/manual/en/{legacy_id}.php' => \LegacyRedirectController::class,
+      '/j/{Keyword}' => \JumpController::class,
+      '/manual/en/{LegacyId}.php' => \LegacyRedirectController::class,
       '/robots.txt' => \RobotsTxtController::class,
-      '/s/{checksum}/{file:.+}' => \StaticResourcesController::class,
+      '/s/{Checksum}/{File:.+}' => \StaticResourcesController::class,
       '/search' => \SearchController::class,
-      '/{product:(?:hack|php)}/reference/' => \APIFullListController::class,
-      '/{product:(?:hack|php)}/reference/{type:(?:class|trait|interface|function)}/' =>
+      '/{Product:(?:hack|php)}/reference/' => \APIFullListController::class,
+      '/{Product:(?:hack|php)}/reference/{Type:(?:class|trait|interface|function)}/' =>
         \APIListByTypeController::class,
-      '/{product:(?:hack|php)}/reference/{type:(?:class|trait|interface|function)}/{class}/{method}/' =>
+      '/{Product:(?:hack|php)}/reference/{Type:(?:class|trait|interface|function)}/{Class}/{Method}/' =>
         \APIMethodPageController::class,
-      '/{product:(?:hack|php)}/reference/{type:(?:class|trait|interface|function)}/{name}/' =>
+      '/{Product:(?:hack|php)}/reference/{Type:(?:class|trait|interface|function)}/{Name}/' =>
         \APIClassPageController::class,
-      '/{product:(?:hhvm|hack)}/' => \GuidesListController::class,
-      '/{product:(?:hhvm|hack)}/{guide}/' =>
+      '/{Product:(?:hhvm|hack)}/' => \GuidesListController::class,
+      '/{Product:(?:hhvm|hack)}/{Guide}/' =>
         \RedirectToGuideFirstPageController::class,
-      '/{product:(?:hhvm|hack)}/{guide}/{page}' => \GuidePageController::class,
+      '/{Product:(?:hhvm|hack)}/{Guide}/{Page}' => \GuidePageController::class,
     };
     return ImmMap {
       \FredEmmott\HackRouter\HttpMethod::GET => $get,

--- a/src/site/controllers/APIClassPageController.php
+++ b/src/site/controllers/APIClassPageController.php
@@ -11,21 +11,23 @@ use HHVM\UserDocumentation\HTMLFileRenderable;
 use HHVM\UserDocumentation\URLBuilder;
 
 final class APIClassPageController extends APIPageController {
+  use APIClassPageControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/')
-      ->apiProduct('product')
+      ->apiProduct('Product')
       ->literal('/reference/')
-      ->definitionType('type')
+      ->definitionType('Type')
       ->literal('/')
-      ->string('name')
+      ->string('Name')
       ->literal('/');
   }
 
   <<__Memoize,__Override>>
   protected function getRootDefinition(): APIIndexEntry {
     $this->redirectIfAPIRenamed();
-    $definition_name = $this->getRequiredStringParam('name');
+    $definition_name = $this->getParameters()->getName();
 
     $index = APIIndex::getIndexForType($this->getDefinitionType());
     if (!array_key_exists($definition_name, $index)) {
@@ -61,7 +63,7 @@ final class APIClassPageController extends APIPageController {
 
   <<__Override>>
   protected function redirectIfAPIRenamed(): void {
-    $redirect_to = $this->getRenamedAPI($this->getRequiredStringParam('name'));
+    $redirect_to = $this->getRenamedAPI($this->getParameters()->getName());
 
     if ($redirect_to === null) {
       return;

--- a/src/site/controllers/APIFullListController.php
+++ b/src/site/controllers/APIFullListController.php
@@ -1,11 +1,11 @@
 <?hh // strict
 
-use HHVM\UserDocumentation\APIIndex;
-use HHVM\UserDocumentation\APINavData;
 use HHVM\UserDocumentation\APIDefinitionType;
-use HHVM\UserDocumentation\PHPAPIIndex;
+use HHVM\UserDocumentation\APIProduct;
 
-final class APIFullListController extends APIListController {
+final class APIFullListController extends WebPageController {
+  use APIFullListControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/')
@@ -14,15 +14,29 @@ final class APIFullListController extends APIListController {
   }
 
   <<__Override>>
-  protected function getDefinitionTypes(): ImmSet<APIDefinitionType> {
-    return new ImmSet(APIDefinitionType::getValues());
-  }
-
-  <<__Override>>
   final protected function getBreadcrumbs(): :ui:breadcrumbs {
     $parents = Map {
       'Hack' => '/hack/',
     };
     return <ui:breadcrumbs parents={$parents} currentPage="Reference" />;
+  }
+
+  <<__Override>>
+  protected async function getTitle(): Awaitable<string> {
+    switch ($this->getParameters()->getProduct()) {
+      case APIProduct::HACK:
+        return 'Hack APIs';
+      case APIProduct::PHP:
+        return 'Supported PHP APIs';
+    }
+  }
+
+  <<__Override>>
+  final protected async function getBody(): Awaitable<XHPRoot> {
+    return
+      <api-list
+        product={$this->getParameters()->getProduct()}
+        types={new ImmSet(APIDefinitionType::getValues())}
+      />;
   }
 }

--- a/src/site/controllers/APIFullListController.php
+++ b/src/site/controllers/APIFullListController.php
@@ -9,7 +9,7 @@ final class APIFullListController extends APIListController {
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/')
-      ->apiProduct('product')
+      ->apiProduct('Product')
       ->literal('/reference/');
   }
 

--- a/src/site/controllers/APIListByTypeController.php
+++ b/src/site/controllers/APIListByTypeController.php
@@ -6,20 +6,20 @@ use HHVM\UserDocumentation\APIDefinitionType;
 use HHVM\UserDocumentation\PHPAPIIndex;
 
 final class APIListByTypeController extends APIListController {
+  use APIListByTypeControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/')
-      ->apiProduct('product')
+      ->apiProduct('Product')
       ->literal('/reference/')
-      ->definitionType('type')
+      ->definitionType('Type')
       ->literal('/');
   }
 
   <<__Override>>
   protected function getDefinitionTypes(): ImmSet<APIDefinitionType> {
-    return ImmSet {
-      APIDefinitionType::assert($this->getRequiredStringParam('type')),
-    };
+    return ImmSet { $this->getParameters()->getType() };
   }
 
   <<__Override>>
@@ -28,7 +28,7 @@ final class APIListByTypeController extends APIListController {
       'Hack' => '/hack/',
       'Reference' => '/hack/reference/',
     };
-    $type = $this->getRequiredStringParam('type');
+    $type = $this->getParameters()->getType();
     return <ui:breadcrumbs parents={$parents} currentPage={ucwords($type)} />;
   }
 }

--- a/src/site/controllers/APIListByTypeController.php
+++ b/src/site/controllers/APIListByTypeController.php
@@ -1,11 +1,9 @@
 <?hh // strict
 
-use HHVM\UserDocumentation\APIIndex;
-use HHVM\UserDocumentation\APINavData;
 use HHVM\UserDocumentation\APIDefinitionType;
-use HHVM\UserDocumentation\PHPAPIIndex;
+use HHVM\UserDocumentation\APIProduct;
 
-final class APIListByTypeController extends APIListController {
+final class APIListByTypeController extends WebPageController {
   use APIListByTypeControllerParametersTrait;
 
   public static function getUriPattern(): UriPattern {
@@ -18,11 +16,6 @@ final class APIListByTypeController extends APIListController {
   }
 
   <<__Override>>
-  protected function getDefinitionTypes(): ImmSet<APIDefinitionType> {
-    return ImmSet { $this->getParameters()->getType() };
-  }
-
-  <<__Override>>
   protected function getBreadcrumbs(): :ui:breadcrumbs {
     $parents = Map {
       'Hack' => '/hack/',
@@ -30,5 +23,24 @@ final class APIListByTypeController extends APIListController {
     };
     $type = $this->getParameters()->getType();
     return <ui:breadcrumbs parents={$parents} currentPage={ucwords($type)} />;
+  }
+
+  <<__Override>>
+  protected async function getTitle(): Awaitable<string> {
+    switch ($this->getParameters()->getProduct()) {
+      case APIProduct::HACK:
+        return 'Hack APIs';
+      case APIProduct::PHP:
+        return 'Supported PHP APIs';
+    }
+  }
+
+  <<__Override>>
+  final protected async function getBody(): Awaitable<XHPRoot> {
+    return
+      <api-list
+        product={$this->getParameters()->getProduct()}
+        types={ImmSet{$this->getParameters()->getType()}}
+      />;
   }
 }

--- a/src/site/controllers/APIListController.php
+++ b/src/site/controllers/APIListController.php
@@ -110,8 +110,9 @@ abstract class APIListController extends WebPageController {
 
   <<__Memoize>>
   final private function getProduct(): APIProduct {
-    return APIProduct::assert(
-      $this->getRequiredStringParam('product')
+    return $this->getParameters_PRIVATE_IMPL()->getEnum(
+      APIProduct::class,
+      'Product',
     );
   }
 }

--- a/src/site/controllers/APIMethodPageController.php
+++ b/src/site/controllers/APIMethodPageController.php
@@ -6,22 +6,25 @@ use HHVM\UserDocumentation\APIMethodIndexEntry;
 use HHVM\UserDocumentation\URLBuilder;
 
 final class APIMethodPageController extends APIPageController {
+  use APIMethodPageControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/')
-      ->apiProduct('product')
+      ->apiProduct('Product')
       ->literal('/reference/')
-      ->definitionType('type')
+      ->definitionType('Type')
       ->literal('/')
-      ->string('class')
+      ->string('Class')
       ->literal('/')
-      ->string('method')
+      ->string('Method')
       ->literal('/');
   }
+
   <<__Memoize,__Override>>
   protected function getRootDefinition(): APIClassIndexEntry {
     $this->redirectIfAPIRenamed();
-    $definition_name = $this->getRequiredStringParam('class');
+    $definition_name = $this->getParameters()->getClass();
     $index = APIIndex::getClassIndex($this->getDefinitionType());
     if (!array_key_exists($definition_name, $index)) {
       throw new HTTPNotFoundException();
@@ -31,7 +34,7 @@ final class APIMethodPageController extends APIPageController {
 
   <<__Memoize>>
   private function getMethodDefinition(): APIMethodIndexEntry {
-    $method_name = $this->getRequiredStringParam('method');
+    $method_name = $this->getParameters()->getMethod();
     $methods = $this->getRootDefinition()['methods'];
     if (!array_key_exists($method_name, $methods)) {
       throw new HTTPNotFoundException();
@@ -70,14 +73,14 @@ final class APIMethodPageController extends APIPageController {
 
   <<__Override>>
   protected function redirectIfAPIRenamed(): void {
-    $redirect_to = $this->getRenamedAPI($this->getRequiredStringParam('class'));
+    $redirect_to = $this->getRenamedAPI($this->getParameters()->getClass());
     if ($redirect_to === null) {
       return;
     }
     $type = $this->getDefinitionType();
     throw new RedirectException(
       URLBuilder::getPathForMethod(shape(
-        'name' => $this->getRequiredStringParam('method'),
+        'name' => $this->getParameters()->getMethod(),
         'className' => $redirect_to,
         'classType' => $type,
       )),

--- a/src/site/controllers/APIPageController.php
+++ b/src/site/controllers/APIPageController.php
@@ -13,8 +13,9 @@ use HHVM\UserDocumentation\URLBuilder;
 abstract class APIPageController extends WebPageController {
   <<__Memoize>>
   final protected function getDefinitionType(): APIDefinitionType {
-    return APIDefinitionType::assert(
-      $this->getRequiredStringParam('type')
+    return $this->getParameters_PRIVATE_IMPL()->getEnum(
+      APIDefinitionType::class,
+      'Type',
     );
   }
 

--- a/src/site/controllers/GuidePageController.php
+++ b/src/site/controllers/GuidePageController.php
@@ -14,31 +14,31 @@ use HHVM\UserDocumentation\URLBuilder;
 use Psr\Http\Message\ServerRequestInterface;
 
 final class GuidePageController extends WebPageController {
+  use GuidePageControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/')
-      ->guidesProduct('product')
+      ->guidesProduct('Product')
       ->literal('/')
-      ->string('guide')
+      ->string('Guide')
       ->literal('/')
-      ->string('page');
+      ->string('Page');
   }
 
   <<__Memoize>>
   private function getProduct(): GuidesProduct {
-    return GuidesProduct::assert(
-      $this->getRequiredStringParam('product')
-    );
+    return $this->getParameters()->getProduct();
   }
 
   <<__Memoize>>
   private function getGuide(): string {
-    return $this->getRequiredStringParam('guide');
+    return $this->getParameters()->getGuide();
   }
 
   <<__Memoize>>
   private function getPage(): string {
-    return $this->getRequiredStringParam('page');
+    return $this->getParameters()->getPage();
   }
 
   public async function getTitle(): Awaitable<string> {
@@ -223,9 +223,9 @@ final class GuidePageController extends WebPageController {
   protected function getInnerContent(): XHPRoot {
     return self::invariantTo404(() ==> {
       $path = GuidesIndex::getFileForPage(
-        GuidesProduct::assert($this->getRequiredStringParam('product')),
-        $this->getRequiredStringParam('guide'),
-        $this->getRequiredStringParam('page'),
+        $this->getProduct(),
+        $this->getGuide(),
+        $this->getPage(),
       );
       return
         <div class="innerContent">{new HTMLFileRenderable($path)}</div>;

--- a/src/site/controllers/GuidesListController.php
+++ b/src/site/controllers/GuidesListController.php
@@ -6,10 +6,12 @@ use HHVM\UserDocumentation\HTMLFileRenderable;
 use HHVM\UserDocumentation\URLBuilder;
 
 final class GuidesListController extends WebPageController {
+  use GuidesListControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/')
-      ->guidesProduct('product')
+      ->guidesProduct('Product')
       ->literal('/');
   }
 
@@ -75,7 +77,7 @@ final class GuidesListController extends WebPageController {
 
   protected function getGuideSummary(string $guide): ?XHPRoot {
     $path = GuidesIndex::getFileForSummary(
-      $this->getRequiredStringParam('product'),
+      $this->getProduct(),
       $guide,
     );
     if (file_get_contents($path)) {
@@ -96,8 +98,6 @@ final class GuidesListController extends WebPageController {
 
   <<__Memoize>>
   private function getProduct(): GuidesProduct {
-    return GuidesProduct::assert(
-      $this->getRequiredStringParam('product')
-    );
+    return $this->getParameters()->getProduct();
   }
 }

--- a/src/site/controllers/JumpController.php
+++ b/src/site/controllers/JumpController.php
@@ -9,14 +9,17 @@ require_once(BuildPaths::JUMP_INDEX);
 final class JumpController
 extends WebController
 implements RoutableGetController {
+  use JumpControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/j/')
-      ->string('keyword');
+      ->string('Keyword');
   }
 
   public function getResponse(): Awaitable<ResponseInterface> {
-    $keyword = $this->getRequiredStringParam('keyword');
+    $keyword = $this->getParameters()->getKeyword();
+
     $data = JumpIndexData::getIndex();
     $url = idx($data, strtolower($keyword));
     if (is_string($url)) {

--- a/src/site/controllers/LegacyRedirectController.php
+++ b/src/site/controllers/LegacyRedirectController.php
@@ -6,15 +6,17 @@ use Psr\Http\Message\ResponseInterface;
 final class LegacyRedirectController
 extends WebController
 implements RoutableGetController {
+  use LegacyRedirectControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/manual/en/')
-      ->string('legacy_id')
+      ->string('LegacyId')
       ->literal('.php');
   }
 
   public async function getResponse(): Awaitable<ResponseInterface> {
-    $id = $this->getRequiredStringParam('legacy_id');
+    $id = $this->getParameters()->getLegacyId();
 
     $url = LegacyRedirects::getUrlForId($id);
     if ($url !== null) {

--- a/src/site/controllers/NonRoutableWebPageController.php
+++ b/src/site/controllers/NonRoutableWebPageController.php
@@ -154,7 +154,7 @@ EOF;
   }
 
   private function getBodyClass(?string $extra_class): string {
-    $class = 'bodyClass'.ucwords($this->getOptionalStringParam('product'));
+    $class = 'bodyClass'.ucwords($this->getRawParameter_UNSAFE('product'));
     if ($extra_class !== null) {
       $class = $class.' '.$extra_class;
     }
@@ -163,7 +163,7 @@ EOF;
 
   private function getTitleContent(string $title): XHPRoot {
     $title_class =
-      "mainTitle mainTitle".$this->getOptionalStringParam('product');
+      "mainTitle mainTitle".$this->getRawParameter_UNSAFE('product');
     return
       <div class={$title_class}>
         <div class="widthWrapper">
@@ -182,7 +182,7 @@ EOF;
 
   protected function getHeader(): XHPRoot {
     $header_class =
-      "header headerType".$this->getOptionalStringParam('product');
+      "header headerType".$this->getRawParameter_UNSAFE('product');
     return
       <div class={$header_class}>
         <div class="widthWrapper">

--- a/src/site/controllers/RedirectToGuideFirstPageController.php
+++ b/src/site/controllers/RedirectToGuideFirstPageController.php
@@ -8,18 +8,21 @@ use Psr\Http\Message\ResponseInterface;
 
 final class RedirectToGuideFirstPageController
 extends WebController implements RoutableGetController {
+  use RedirectToGuideFirstPageControllerParametersTrait;
+  
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/')
-      ->guidesProduct('product')
+      ->guidesProduct('Product')
       ->literal('/')
-      ->string('guide')
+      ->string('Guide')
       ->literal('/');
   }
 
   public async function getResponse(): Awaitable<ResponseInterface> {
-    $product = GuidesProduct::assert($this->getRequiredStringParam('product'));
-    $guide = $this->getRequiredStringParam('guide');
+    $params = $this->getParameters();
+    $product = GuidesProduct::assert($params->getProduct());
+    $guide = $params->getGuide();
     $path = self::invariantTo404(() ==> {
       $pages = GuidesIndex::getPages($product, $guide);
       $page = $pages[0];

--- a/src/site/controllers/SearchController.php
+++ b/src/site/controllers/SearchController.php
@@ -1,5 +1,7 @@
 <?hh // strict
 
+use FredEmmott\HackRouter\StringRequestParameter;
+use FredEmmott\HackRouter\StringRequestParameterSlashes;
 use HHVM\UserDocumentation\APIIndex;
 use HHVM\UserDocumentation\GuidesIndex;
 use HHVM\UserDocumentation\PHPAPIIndex;
@@ -8,8 +10,24 @@ use HHVM\UserDocumentation\SearchResultSet;
 use Psr\Http\Message\ServerRequestInterface;
 
 final class SearchController extends WebPageController {
+  use SearchControllerParametersTrait;
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())->literal('/search');
+  }
+
+  <<__Override>>
+  protected static function getExtraParametersSpec(
+  ): self::TParameterDefinitions {
+    return shape(
+      'required' => ImmVector {
+        new StringRequestParameter(
+          StringRequestParameterSlashes::ALLOW_SLASHES,
+          'term',
+        ),
+      },
+      'optional' => ImmVector { },
+    );
   }
 
   public async function getTitle(): Awaitable<string> {
@@ -65,7 +83,7 @@ final class SearchController extends WebPageController {
 
   <<__Memoize>>
   private function getSearchTerm(): string {
-    return $this->getRequiredStringParam('term');
+    return $this->getParameters()->getterm();
   }
 
   private function getSearchResults(): SearchResultSet {

--- a/src/site/controllers/codegen/APIClassPageControllerParameters.php
+++ b/src/site/controllers/codegen/APIClassPageControllerParameters.php
@@ -1,0 +1,41 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<90cc77bf4ca7f4d72a8371ff63306d0a>>
+ */
+
+class APIClassPageControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getProduct(): \HHVM\UserDocumentation\APIProduct {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\APIProduct::class,
+      'Product',
+    );
+  }
+
+  final public function getType(): \HHVM\UserDocumentation\APIDefinitionType {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\APIDefinitionType::class,
+      'Type',
+    );
+  }
+
+  final public function getName(): string {
+    return $this->getParameters()->getString('Name');
+  }
+}
+
+trait APIClassPageControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): APIClassPageControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new APIClassPageControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/APIFullListControllerParameters.php
+++ b/src/site/controllers/codegen/APIFullListControllerParameters.php
@@ -1,0 +1,30 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<44a96b0bcbb3fe2081295e9bc34ea0c6>>
+ */
+
+class APIFullListControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getProduct(): \HHVM\UserDocumentation\APIProduct {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\APIProduct::class,
+      'Product',
+    );
+  }
+}
+
+trait APIFullListControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): APIFullListControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new APIFullListControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/APIListByTypeControllerParameters.php
+++ b/src/site/controllers/codegen/APIListByTypeControllerParameters.php
@@ -1,0 +1,37 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<94478ff7a21c5f1942c24b504b4ef057>>
+ */
+
+class APIListByTypeControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getProduct(): \HHVM\UserDocumentation\APIProduct {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\APIProduct::class,
+      'Product',
+    );
+  }
+
+  final public function getType(): \HHVM\UserDocumentation\APIDefinitionType {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\APIDefinitionType::class,
+      'Type',
+    );
+  }
+}
+
+trait APIListByTypeControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): APIListByTypeControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new APIListByTypeControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/APIMethodPageControllerParameters.php
+++ b/src/site/controllers/codegen/APIMethodPageControllerParameters.php
@@ -1,0 +1,45 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<40c1d8fc23c269471b6d8dcfdddc8123>>
+ */
+
+class APIMethodPageControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getProduct(): \HHVM\UserDocumentation\APIProduct {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\APIProduct::class,
+      'Product',
+    );
+  }
+
+  final public function getType(): \HHVM\UserDocumentation\APIDefinitionType {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\APIDefinitionType::class,
+      'Type',
+    );
+  }
+
+  final public function getClass(): string {
+    return $this->getParameters()->getString('Class');
+  }
+
+  final public function getMethod(): string {
+    return $this->getParameters()->getString('Method');
+  }
+}
+
+trait APIMethodPageControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): APIMethodPageControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new APIMethodPageControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/GuidePageControllerParameters.php
+++ b/src/site/controllers/codegen/GuidePageControllerParameters.php
@@ -1,0 +1,38 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<b0d60ca12dd3b73d6c9ee91c0223e49b>>
+ */
+
+class GuidePageControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getProduct(): \HHVM\UserDocumentation\GuidesProduct {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\GuidesProduct::class,
+      'Product',
+    );
+  }
+
+  final public function getGuide(): string {
+    return $this->getParameters()->getString('Guide');
+  }
+
+  final public function getPage(): string {
+    return $this->getParameters()->getString('Page');
+  }
+}
+
+trait GuidePageControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): GuidePageControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new GuidePageControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/GuidesListControllerParameters.php
+++ b/src/site/controllers/codegen/GuidesListControllerParameters.php
@@ -1,0 +1,30 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<79d34d74bd045dc55fb7d8d4e68e369e>>
+ */
+
+class GuidesListControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getProduct(): \HHVM\UserDocumentation\GuidesProduct {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\GuidesProduct::class,
+      'Product',
+    );
+  }
+}
+
+trait GuidesListControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): GuidesListControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new GuidesListControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/HomePageControllerParameters.php
+++ b/src/site/controllers/codegen/HomePageControllerParameters.php
@@ -1,0 +1,23 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<7f95002c11fcb4e7d4d9ffc7c546bd90>>
+ */
+
+class HomePageControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+}
+
+trait HomePageControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): HomePageControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new HomePageControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/JumpControllerParameters.php
+++ b/src/site/controllers/codegen/JumpControllerParameters.php
@@ -1,0 +1,27 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<1a059f56735a0005310b2121999df1f1>>
+ */
+
+class JumpControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getKeyword(): string {
+    return $this->getParameters()->getString('Keyword');
+  }
+}
+
+trait JumpControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): JumpControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new JumpControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/LegacyRedirectControllerParameters.php
+++ b/src/site/controllers/codegen/LegacyRedirectControllerParameters.php
@@ -1,0 +1,27 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<9adc8fa8149f224ba3ce3c3ab28cdae8>>
+ */
+
+class LegacyRedirectControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getLegacyId(): string {
+    return $this->getParameters()->getString('LegacyId');
+  }
+}
+
+trait LegacyRedirectControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): LegacyRedirectControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new LegacyRedirectControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/RedirectToGuideFirstPageControllerParameters.php
+++ b/src/site/controllers/codegen/RedirectToGuideFirstPageControllerParameters.php
@@ -1,0 +1,35 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<bf25cd9396d03249bb97468330513547>>
+ */
+
+class RedirectToGuideFirstPageControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getProduct(): \HHVM\UserDocumentation\GuidesProduct {
+    return $this->getParameters()->getEnum(
+      \HHVM\UserDocumentation\GuidesProduct::class,
+      'Product',
+    );
+  }
+
+  final public function getGuide(): string {
+    return $this->getParameters()->getString('Guide');
+  }
+}
+
+trait RedirectToGuideFirstPageControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(
+  ): RedirectToGuideFirstPageControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new RedirectToGuideFirstPageControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/RobotsTxtControllerParameters.php
+++ b/src/site/controllers/codegen/RobotsTxtControllerParameters.php
@@ -1,0 +1,23 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<e48cb15cd478a49918c73bd123dea89e>>
+ */
+
+class RobotsTxtControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+}
+
+trait RobotsTxtControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): RobotsTxtControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new RobotsTxtControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/SearchControllerParameters.php
+++ b/src/site/controllers/codegen/SearchControllerParameters.php
@@ -1,0 +1,27 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<faf3c34b99c14c4029895ddb6b824301>>
+ */
+
+class SearchControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getterm(): string {
+    return $this->getParameters()->getString('term');
+  }
+}
+
+trait SearchControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): SearchControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new SearchControllerParameters($params);
+  }
+}

--- a/src/site/controllers/codegen/StaticResourcesControllerParameters.php
+++ b/src/site/controllers/codegen/StaticResourcesControllerParameters.php
@@ -1,0 +1,35 @@
+<?hh // strict
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run /var/www/bin/build.php
+ *
+ *
+ * @generated SignedSource<<6a90f63d11a427c1aac6092a710eacc5>>
+ */
+
+class StaticResourcesControllerParameters
+  extends \FredEmmott\HackRouter\RequestParametersCodegen {
+
+  final public function getChecksum(): string {
+    return $this->getParameters()->getString('Checksum');
+  }
+
+  final public function getFile(): string {
+    return $this->getParameters()->getString('File');
+  }
+
+  final public function getMTime(): ?int {
+    return $this->getParameters()->getOptionalInt('MTime');
+  }
+}
+
+trait StaticResourcesControllerParametersTrait {
+
+  require extends \WebController;
+
+  final public function getParameters(): StaticResourcesControllerParameters {
+    $params = $this->getParameters_PRIVATE_IMPL();
+    return new StaticResourcesControllerParameters($params);
+  }
+}

--- a/src/site/xhp/api-list.php
+++ b/src/site/xhp/api-list.php
@@ -6,21 +6,14 @@ use HHVM\UserDocumentation\APIDefinitionType;
 use HHVM\UserDocumentation\APIProduct;
 use HHVM\UserDocumentation\PHPAPIIndex;
 
-abstract class APIListController extends WebPageController {
-  abstract protected function getDefinitionTypes(): ImmSet<APIDefinitionType>;
-
-  final public async function getTitle(): Awaitable<string> {
-    switch ($this->getProduct()) {
-      case APIProduct::HACK:
-        return 'Hack APIs';
-      case APIProduct::PHP:
-        return 'Supported PHP APIs';
-    }
-  }
+class :api-list extends :x:element {
+  attribute
+    APIProduct product @required,
+    ImmSet<APIDefinitionType> types @required;
 
   final private function getDefinitions(
   ): Map<APIDefinitionType, Map<string, string>> {
-    switch ($this->getProduct()) {
+    switch ($this->:product) {
       case APIProduct::HACK:
         return $this->getHackDefinitions();
       case APIProduct::PHP:
@@ -31,7 +24,7 @@ abstract class APIListController extends WebPageController {
   final private function getHackDefinitions(
   ): Map<APIDefinitionType, Map<string, string>> {
     $out = Map {};
-    foreach ($this->getDefinitionTypes() as $type) {
+    foreach ($this->:types as $type) {
       $index = APIIndex::getIndexForType($type);
       $out[$type] = Map { };
       foreach ($index as $node) {
@@ -43,10 +36,9 @@ abstract class APIListController extends WebPageController {
 
   final private function getPHPDefinitions(
   ): Map<APIDefinitionType, Map<string, string>> {
-    $supported_types = $this->getDefinitionTypes();
     $out = Map { };
 
-    foreach ($supported_types as $type) {
+    foreach ($this->:types as $type) {
       $out[$type] = Map { };
     }
 
@@ -55,7 +47,7 @@ abstract class APIListController extends WebPageController {
       if (!$data['supportedInHHVM']) {
         continue;
       }
-      if (!$supported_types->contains($data['type'])) {
+      if (!$this->:types->contains($data['type'])) {
         continue;
       }
       $out[$data['type']][$name] = $data['url'];
@@ -63,7 +55,7 @@ abstract class APIListController extends WebPageController {
     return $out->filter($map ==> $map->count() !== 0);
   }
 
-  final protected function getInnerContent(): XHPRoot {
+  final private function getInnerContent(): XHPRoot {
     $defs = $this->getDefinitions();
 
     $root = <div class="referenceList" />;
@@ -86,7 +78,7 @@ abstract class APIListController extends WebPageController {
       );
     }
 
-    if ($this->getProduct() === APIProduct::HACK) {
+    if ($this->:product === APIProduct::HACK) {
       return (
         <x:frag>
           <p>
@@ -101,18 +93,10 @@ abstract class APIListController extends WebPageController {
     return $root;
   }
 
-  final protected async function getBody(): Awaitable<XHPRoot> {
+  final protected function render(): XHPRoot {
     return
       <div class="apiListWrapper">
         {$this->getInnerContent()}
       </div>;
-  }
-
-  <<__Memoize>>
-  final private function getProduct(): APIProduct {
-    return $this->getParameters_PRIVATE_IMPL()->getEnum(
-      APIProduct::class,
-      'Product',
-    );
   }
 }


### PR DESCRIPTION
Basically replaces `$x = $this->getRequiredStringParam('foo')` with `$x = $this->getParameters()->getFoo()`; improves typechecker and IDE support.

Take advantage of this to remove the abstract APIListController, replacing inheritance with composition