### PR TITLE
Explain that nullable fields in shapes are also optional

### DIFF
--- a/guides/hack/26-shapes/01-introduction.md
+++ b/guides/hack/26-shapes/01-introduction.md
@@ -26,13 +26,17 @@ Note that an integer literal **cannot** be used directly as a field name.
 
 The names of all fields in a given shape definition must be distinct and have the same form.
 
-### All Fields Are Required
+### All Non-Nullable Fields Are Required
 
 When returning your shape from a function, for example, all fields must be accounted for; otherwise the Hack typechecker will raise an error.
 
 @@ introduction-examples/fields.php.type-errors @@
 
 In the above example, we forgot to set the `name` field of the shape. Note that HHVM will still run the code since it really is just an array under the covers.
+
+### Nullable Fields Are Optional
+
+The typechecker conflates optional and nullable. `shape('name' => ?string)` will match both `shape('name' => null)` and `shape()`. Accordingly, the typechecker will *not* raise an error if you omit a nullable field. The runtime, however, will raise an `OutOfBoundsException` if you try to read an omitted field.
 
 ## Class Constants
 


### PR DESCRIPTION
Warn shape users that the typechecker conflates optional and nullable.