### PR TITLE
Include an illustration of the danger of implicit casting for enums

### DIFF
--- a/guides/hack/28-enums/01-introduction-examples/implicit-casting.php
+++ b/guides/hack/28-enums/01-introduction-examples/implicit-casting.php
@@ -21,13 +21,24 @@ function give_shirt(Size $size): void {
 
 function sales(): void {
   // Implict casting at work
-  say_greeting_with_size(Size::SMALL);
+  $s = Size::SMALL;
+  say_greeting_with_size($s);
   // No implicit casting this way though.
   // To go from the underlying type to the enum type, Hack provides builtin
   // enum functions to help you. The assert function basically tells the
   // typechecker that you are NOT going to give it a value that doesn't exist
   // in the enum.
   give_shirt(Size::assert("small"));
+  
+  // The downside to implicit casting is that many (if not most) enumerations
+  // have a specific meaning that doesn't make sense to use in the context of
+  // its most base type (int or string). For example, an ambiguously-named
+  // variable, several lines down in a function, is easy to mistake for another:
+  if (Str\contains($s, 'cash')) {
+    // We will never enter this loop. The line above would have been an error
+    // if Size had not been typed as a string.
+    record_cash_payment();
+  }
 }
 
 sales();


### PR DESCRIPTION
The current docs do not illustrate the trouble in allowing implicit casting, which is that a string or int with semantic meaning is almost never correct input to a function that wants "normal" meaning. Normal meaning being, counts or quantities for ints, and messages or blobs for strings.