### PR TITLE
Set a default namespace to improve auto-linkify

### DIFF
--- a/guides/hack/22-async/02-awaitables.md
+++ b/guides/hack/22-async/02-awaitables.md
@@ -1,3 +1,9 @@
+```yamlmeta
+{
+  "namespace": "HH\\Asio"
+}
+```
+
 An *awaitable* is the key construct in `async` code. An awaitable is a first-class Hack object that represents a possibly asynchronous operation that may or may not have completed. You `await` the awaitable until the operation has completed. 
 
 ## `Awaitable`

--- a/src/typedefs.php
+++ b/src/typedefs.php
@@ -37,6 +37,7 @@ type YAMLMeta = shape(
   ?'fbonly messages' => vec<string>,
   ?'min-versions' => dict<RequirableProduct, string>,
   ?'experimental' => bool,
+  ?'namespace' => string,
 );
 
 

--- a/tests/AutoLinkifyAPITest.php
+++ b/tests/AutoLinkifyAPITest.php
@@ -70,6 +70,12 @@ class AutoLinkifyAPITest extends \PHPUnit_Framework_TestCase {
           'KeyedIterable::map()',
           '/hack/reference/interface/HH.KeyedIterable/map/',
         ),
+      'Default Namepsace' =>
+        tuple(
+          '/hack/async/awaitables',
+          'join',
+          '/hack/reference/function/HH.Asio.join/'
+        ),
     ];
   }
 


### PR DESCRIPTION
Add support for a metadata field to specify the default namespace for a block to keep short code references but allow the auto-linker to resolve the correct reference.

Fixes #522 