### PR TITLE
Update emacs plugin documentation to point to new hack-mode

### DIFF
--- a/guides/hack/25-typechecker/08-editors.md
+++ b/guides/hack/25-typechecker/08-editors.md
@@ -10,7 +10,7 @@ The [Nuclide editor](http://nuclide.io/) has first-class support for Hack. It no
 
 ## Emacs
 
-Emacs users will find a plugin inside `/usr/share/hhvm/hack/emacs`, when installing Hack from a supported HHVM package. And [this is the source code](https://github.com/facebook/hhvm/tree/master/hphp/hack/editor-plugins/emacs)
+ Emacs users can find a package in [Github](https://github.com/hhvm/hack-mode) with installation instructions in the [README](https://github.com/hhvm/hack-mode/blob/master/README.md) contained therein.
 
 ## Other
 


### PR DESCRIPTION
Summary: The new plugin now lives in its own repo. The documentation
for emacs was copied verbatim from the Vim section.

Reviewers: joelm, fredemmott