### PR TITLE
Correct link to lambda section

### DIFF
--- a/guides/hack/46-callables/02-special-functions.md
+++ b/guides/hack/46-callables/02-special-functions.md
@@ -3,7 +3,7 @@ callables that are supported in PHP, and the typechecker understands them - they
 produce a callable with the same return and parameter types as the function
 they reference.
 
-An alternative is to [use lambdas](#about_lambdas).
+An alternative is to [use lambdas](#about-lambdas).
 
 ## `fun()`
 


### PR DESCRIPTION
Currently it links to `#about_lambdas` which does not work as the category is `#about-lambdas`.

Before: https://docs.hhvm.com/hack/callables/special-functions#about_lambdas
After: https://docs.hhvm.com/hack/callables/special-functions#about-lambdas