### PR TITLE
Don't bother showing "This API is part of HSL"

### DIFF
--- a/src/markdown-extensions/YamlFrontMatterBlock.php
+++ b/src/markdown-extensions/YamlFrontMatterBlock.php
@@ -101,10 +101,10 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
     // TODO: fix XHP in namespaces
     return new UnparsedBlocks\HTMLBlock(
       '<div class="apiTopMessage apiFromLib">'.
-        'This API is part of '.
+        'Requires '.
         '<a href="https://github.com/'.$lib['github'].'/">'.
         $lib['name'].
-        '</a>, not HHVM itself.'.
+        '</a> to be installed.'.
       '</div>',
     );
   }


### PR DESCRIPTION
The breadcrumbs already show where the function is. Removing this text
ensures that the first sentence on the page is more useful to the
user, the overview of the function/class.

cc @fredemmott, let me know if you have any objections.