### PR TITLE
use file_get_contents instead of curl

### DIFF
--- a/src/build/PHPIniSupportInHHVMBuildStep.php
+++ b/src/build/PHPIniSupportInHHVMBuildStep.php
@@ -61,8 +61,8 @@ final class PHPIniSupportInHHVMBuildStep extends BuildStep {
     \libxml_use_internal_errors(true);
     // UNSAFE
     $dom = new \DomDocument();
-    $html_content = \HH\Asio\join(
-      \HH\Asio\curl_exec('http://php.net/manual/en/ini.list.php')
+    $html_content = \file_get_contents(
+      'http://php.net/manual/en/ini.list.php'
     );
     $dom->loadHTML($html_content);
     // UNSAFE


### PR DESCRIPTION
using `HH\Asio\curl_exec` causes the following error under hhvm 3.30.1 : 
```
Fatal error: Uncaught Error: Class undefined: SleepWaitHandle in /home/saif/git/user-documentation/src/build/PHPIniSupportInHHVMBuildStep.php:66
Stack trace:
#0 (): HH\Asio\curl_exec()
#1 /home/saif/git/user-documentation/src/build/PHPIniSupportInHHVMBuildStep.php(66): HH\Asio\join()
#2 /home/saif/git/user-documentation/src/build/PHPIniSupportInHHVMBuildStep.php(37): HHVM\UserDocumentation\PHPIniSupportInHHVMBuildStep->getPHPSettingsWithURLs()
#3 /home/saif/git/user-documentation/src/build/PHPIniSupportInHHVMBuildStep.php(24): HHVM\UserDocumentation\PHPIniSupportInHHVMBuildStep->getIndexData()
#4 /home/saif/git/user-documentation/bin/build.php(76): HHVM\UserDocumentation\PHPIniSupportInHHVMBuildStep->buildAll()
#5 /home/saif/git/user-documentation/bin/build.php(83): HHVM\UserDocumentation\build_site()
#6 {main}
```