### PR TITLE
fix parse_tar() for long file names

### DIFF
--- a/src/utils/extract_tar.hack
+++ b/src/utils/extract_tar.hack
@@ -102,6 +102,20 @@ function parse_tar(
         // tarballs with comment=COMMIT_HASH; just ignore it.
         $consume($size);
         break;
+      case 'x':
+        // Extended header, see https://tinyurl.com/pax-extended-header.
+        list($_, $extended_header_content) = Str\split($consume($size), ' ', 2);
+        list($key, $value) = Str\split($extended_header_content, '=', 2);
+        $value = Str\trim_right($value, "\n");
+        switch ($key) {
+          case 'path':
+            $next_file_name = $value;
+            break;
+          default:
+            throw
+              new \Exception("Tar extended header '$key' is not implemented");
+        }
+        break;
       default:
         throw new \Exception("Tar entry type '$type' is not implemented");
     }


### PR DESCRIPTION
Long file names are stored using "extended headers", which are currently unsupported by parse_tar(), so bin/build.php crashes on HHVM 4.16.

After this fix, it succeeds. Some debug outputs to show that it works as expected: https://gist.github.com/jjergus/4a666b706f3cb266d1e02f9557094749