### PR TITLE
fix examples

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -405,16 +405,16 @@
         },
         {
             "name": "hhvm/hhast",
-            "version": "v4.15.0",
+            "version": "v4.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhast.git",
-                "reference": "6b127b01616bf61139b931200320c901815ecf83"
+                "reference": "82ac0e7f15ee67c4299335dbd02b62c12ae74f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/6b127b01616bf61139b931200320c901815ecf83",
-                "reference": "6b127b01616bf61139b931200320c901815ecf83",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/82ac0e7f15ee67c4299335dbd02b62c12ae74f81",
+                "reference": "82ac0e7f15ee67c4299335dbd02b62c12ae74f81",
                 "shasum": ""
             },
             "require": {
@@ -449,7 +449,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2019-07-22T16:33:23+00:00"
+            "time": "2019-08-01T21:11:43+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",

--- a/src/hh-apidoc-extensions/PageSections/Examples.php
+++ b/src/hh-apidoc-extensions/PageSections/Examples.php
@@ -18,19 +18,20 @@ use namespace HH\Lib\{C, Str, Vec};
 final class Examples extends PageSection {
   <<__Override>>
   public function getMarkdown(): ?string {
-    $path = LocalConfig::ROOT.'/api-examples/';
     if ($this->parent !== null) {
-      $path .= 'class.'.$this->parent->getName().'/';
+      $subdirectory = 'class.'.$this->parent->getName().'/';
     } else {
-      $path .= 'function';
+      $subdirectory = 'function.';
     }
-    $path .= Str\replace(
-      $this->definition->getName(),
-      "\\",
-      '.',
+    $subdirectory .= $this->definition->getName();
+
+    $path = Str\format(
+      '%s/api-examples/%s',
+      LocalConfig::ROOT,
+      Str\replace($subdirectory, '\\', '.'),
     );
 
-    $examples = Vec\concat(\glob($path.'/*.php'), \glob($path.'/*.php'))
+    $examples = Vec\concat(\glob($path.'/*.md'), \glob($path.'/*.php'))
       |> Vec\map($$, $file ==> \pathinfo($file, \PATHINFO_FILENAME))
       |> keyset($$);
 


### PR DESCRIPTION
Examples are broken for

1. all functions
2. any class in a namespace
3. any examples without code (.md only)

This fixes all of it, and adds a test.

Depends on #698, otherwise the test fails because we have examples for some classes that are currently not included in the docs!