### PR TITLE
Remove reified class property access example

### DIFF
--- a/guides/hack/12-generics/20-reified-generics-examples/access.php
+++ b/guides/hack/12-generics/20-reified-generics-examples/access.php
@@ -4,20 +4,17 @@ namespace Hack\UserDocumentation\Generics\ReifiedGenerics\Examples\Access;
 
 class C {
   const string class_const = "hi";
-  public static string $class_propery = "hi";
   public static function h<reify T>(): void {}
 }
 
 // Without reified generics
 function f<T as C>(classname<T> $x): void {
   $x::class_const;
-  $x::$class_propery;
   $x::h<int>();
 }
 
 // With reified generics
 function g<reify T as C>(): void {
   T::class_const;
-  T::$class_propery;
   T::h<int>();
 }

--- a/guides/hack/12-generics/20-reified-generics.md
+++ b/guides/hack/12-generics/20-reified-generics.md
@@ -59,9 +59,12 @@ function f<<<__Newable>> reify T as A<string>>(): A<string> {
 f<A<int>>();
 ```
 
-## Accessing a class constant / static class property / static class method
+## Accessing a class constant / static class method
 
 @@ reified-generics-examples/access.php @@
+
+Accessing static class properties (`T::$class_property`) is currently not
+supported.
 
 ## Hack Arrays
 


### PR DESCRIPTION
This was never supported, but was briefly accidentally allowed.
See https://github.com/facebook/hhvm/commit/f7a349134d2e135168e9b779afafd8b8c8bd1825