### PR TITLE
fix clowny automatic links

### DIFF
--- a/src/build/UnifiedAPIIndexBuildStep.php
+++ b/src/build/UnifiedAPIIndexBuildStep.php
@@ -115,12 +115,6 @@ final class UnifiedAPIIndexBuildStep extends BuildStep {
         $name = $def['name'];
         $maybe_set($name, $def['urlPath']);
 
-        $ns_pos = \strrpos($name, "\\");
-        if ($ns_pos !== false) {
-          $name = \substr($name, $ns_pos + 1);
-          $maybe_set($name, $def['urlPath']);
-        }
-
         if ($type === APIDefinitionType::FUNCTION_DEF) {
           continue;
         }

--- a/src/site/controllers/JumpController.php
+++ b/src/site/controllers/JumpController.php
@@ -17,6 +17,8 @@ final class JumpController
   implements RoutableGetController {
   use JumpControllerParametersTrait;
 
+  const keyset<string> PREFIXES = keyset['', 'HH\\', 'HH\\Lib\\', 'HH\\Asio\\'];
+
   public static function getUriPattern(): UriPattern {
     return (new UriPattern())
       ->literal('/j/')
@@ -30,9 +32,11 @@ final class JumpController
     $keyword = $this->getParameters()['Keyword'];
 
     $data = JumpIndexData::getIndex();
-    $url = idx($data, strtolower($keyword));
-    if ($url is string) {
-      throw new RedirectException($url);
+    foreach (self::PREFIXES as $prefix) {
+      $url = idx($data, strtolower($prefix.$keyword));
+      if ($url is string) {
+        throw new RedirectException($url);
+      }
     }
 
     throw new RedirectException('/search?term='.urlencode($keyword));


### PR DESCRIPTION
This part of code results in linking common things like `string`, `void`, `null`, `Exception` to random unrelated pages.

See build diff: https://gist.github.com/jjergus/f0ee79cd7997380c382e7f5908e38401

Note we already have logic that (correctly) links words even if they're only partial names, so we shouldn't need this one: https://github.com/hhvm/user-documentation/blob/master/src/markdown-extensions/AutoLinkifyInline.php#L73