### PR TITLE
Update documentation for inout parameters to cover restrictions correctly

### DIFF
--- a/guides/hack/05-functions/20-inout-parameters.md
+++ b/guides/hack/05-functions/20-inout-parameters.md
@@ -24,13 +24,12 @@ flow resumes inside the caller's scope.
   whether an argument will be passed with these semantics. It is both a
   typechecker and runtime error if a function expects an inout parameter but the
   programmer fails to annotate the argument as inout, or vice versa.
-- An inout argument must be a *modifiable lvalue*, e.g. variables and other
-  expressions that can appear on the left-hand side of an assignment expression
-  in Hack. If the expression produces side effects, those effects are observed
-  only once. If the lvalue's type cannot change (e.g. it is a class property or
-  a variable whose lifetime extends beyond the enclosing scope), then that type
-  must be the same as the type of the corresponding inout parameter. Otherwise,
-  the lvalue's type may initially be a subtype of the parameter's type.
+- Arguments for inout parameters are local variables with an arbitrary number of
+  index expressions allowed. In other words, they should be local variables
+  (`$x`) or indexed elements contained inside a local (`$vec[$y][z()][2]`).
+  Every intermediate base in the index chain should also be a value-typed
+  container (e.g. vec, dict, keyset, or array). If the argument expression
+  produces side effects, those effects are observed only once.
 - The same lvalue cannot be used for multiple inout arguments in the same
   function call (more generally, the lvalue cannot appear more than once in any
   lvalue context within the full expression, including other function calls or


### PR DESCRIPTION
Previously the doc explicitly mentioned possiblity of passing a class property via inout. This was never supported for inout parameters and there are no plans to support it.
Update documentation to clearly state restrictions on inout arguments (local variables, possibly with some index access chained on them) and remove the explanation about type invariance - it's not applicable, because we do not support typehints on local variables. It may be worth writing another paragraph on how typing works for inout, but I'm going to punt on wordsmithing that for now.