### PR TITLE
magically strip boilerplate from examples

### DIFF
--- a/guides/hack/01-getting-started/01-getting-started-examples/myfirstprogram.hack
+++ b/guides/hack/01-getting-started/01-getting-started-examples/myfirstprogram.hack
@@ -1,3 +1,5 @@
+// @example-start We want a complete example program so don't strip boilerplate.
+
 namespace Hack\GettingStarted\MyFirstProgram;
 
 <<__EntryPoint>>

--- a/guides/hack/02-source-code-fundamentals/37-namespaces-examples/using-namespaces.php
+++ b/guides/hack/02-source-code-fundamentals/37-namespaces-examples/using-namespaces.php
@@ -1,5 +1,7 @@
 <?hh // strict
 
+// @example-start Don't strip namespace declaration in this example.
+
 namespace Hack\UserDocumentation\Fundamentals\Namespaces\Examples\Main;
 
 require_once("namespaces.inc.php");


### PR DESCRIPTION
See comments in code for explanation of what gets stripped.

There are incantations available to override the magic, which I used in 2 examples where the boilerplate is actually important.

Build diff: https://gist.github.com/jjergus/b7136a277e2a44d6b65556f5bbe5bc90