### PR TITLE
fix UpdateTagsCLI

### DIFF
--- a/src/build/UpdateTagsCLI.hack
+++ b/src/build/UpdateTagsCLI.hack
@@ -54,6 +54,7 @@ final class UpdateTagsCLI extends CLIBase {
       $req = \curl_init($url);
       \curl_setopt($req, \CURLOPT_USERAGENT, "docs.hhvm.com update-versions.h");
 
+      /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
       $json = await \HH\Asio\curl_exec($req);
       $more_tags = \json_decode(
         $json, /* assoc = */

--- a/src/build/UpdateTagsCLI.hack
+++ b/src/build/UpdateTagsCLI.hack
@@ -12,7 +12,7 @@ namespace HHVM\UserDocumentation;
 
 use type Facebook\CLILib\CLIBase;
 use namespace Facebook\CLILib\CLIOptions;
-use namespace HH\Lib\{C, Dict, Str, Vec};
+use namespace HH\Lib\{C, Dict, Keyset, Str, Vec};
 use namespace Facebook\HackCodegen as CG;
 
 final class UpdateTagsCLI extends CLIBase {
@@ -43,25 +43,40 @@ final class UpdateTagsCLI extends CLIBase {
     string $project,
     string $prefix,
   ): Awaitable<string> {
-    $url = Str\format(
-      'https://api.github.com/repos/%s/tags?per_page=100',
+    $tags = keyset[];
+    for ($page = 1; $page <= 10; ++$page) {
+      $url = Str\format(
+        'https://api.github.com/repos/%s/tags?per_page=100&page=%d',
+        $project,
+        $page,
+      );
+
+      $req = \curl_init($url);
+      \curl_setopt($req, \CURLOPT_USERAGENT, "docs.hhvm.com update-versions.h");
+
+      $json = await \HH\Asio\curl_exec($req);
+      $more_tags = \json_decode(
+        $json, /* assoc = */
+        true, /* depth = */
+        512,
+        \JSON_FB_HACK_ARRAYS,
+      )
+        |> Vec\map($$, $tag ==> $tag['name'] as string);
+
+      if (C\is_empty($more_tags)) {
+        // We reached the last page.
+        return Vec\filter($tags, $tag ==> Str\starts_with($tag, $prefix))
+          |> Vec\sort($$, ($a, $b) ==> \version_compare($a, $b))
+          |> C\lastx($$);
+      }
+
+      $tags = Keyset\union($tags, $more_tags);
+    }
+
+    invariant_violation(
+      'GitHub project %s has too many tags to process, giving up.',
       $project,
     );
-
-    $req = \curl_init($url);
-    \curl_setopt($req, \CURLOPT_USERAGENT, "docs.hhvm.com update-versions.h");
-
-    $json = await \HH\Asio\curl_exec($req);
-    return \json_decode(
-      $json, /* assoc = */
-      true, /* depth = */
-      512,
-      \JSON_FB_HACK_ARRAYS,
-    )
-      |> Vec\map($$, $tag ==> $tag['name'] as string)
-      |> Vec\filter($$, $tag ==> Str\starts_with($tag, $prefix))
-      |> Vec\sort($$, ($a, $b) ==> \version_compare($a, $b))
-      |> C\lastx($$);
   }
 
   private async function getHHVMTagAsync(): Awaitable<string> {


### PR DESCRIPTION
`bin/update-versions` doesn't work anymore because the latest HHVM version is no longer on the first returned page of tags (maybe the ordering has changed? AFAIK GitHub doesn't guarantee any order).

I couldn't find any way to request specific ordering (latest tags first, would be the most useful one), either for tags or for releases :( so I guess iterating over all pages is the only option?

Here's the ordering I am currently getting: https://gist.github.com/jjergus/4d71dccb5853af478a98149c3ca62d6c -- the latest release is in the middle :/