### PR TITLE
Sort API indexes

### DIFF
--- a/src/build/HHAPIDocBuildStep.php
+++ b/src/build/HHAPIDocBuildStep.php
@@ -135,6 +135,10 @@ final class HHAPIDocBuildStep extends BuildStep {
     APIProduct $product,
     vec<Documentable> $documentables,
   ): ProductAPIIndexShape {
+    $documentables = Vec\sort_by(
+      $documentables,
+      $d ==> $d['definition']->getName(),
+    );
     return shape(
       'class' => self::createClassishIndex(
         $product,


### PR DESCRIPTION
I guess file names used to do this, but not any more. While testing
PR #761, I saw that `Regex\` was before `C\`; this fixes that.