### PR TITLE
Add fb-specific documentation link to 'Getting Started' page

### DIFF
--- a/guides/hack/01-getting-started/01-getting-started.md
+++ b/guides/hack/01-getting-started/01-getting-started.md
@@ -1,3 +1,10 @@
+```yamlmeta
+{
+  "fbonly messages": [
+    "Unless you are specifically working on open source Hack code, you want [Facebook's internal documentation](https://our.internmc.facebook.com/intern/wiki/First-app/) instead."
+  ]
+}
+```
 ## Overview
 
 The prerequisites you need to write and execute Hack code are pretty straightforward:


### PR DESCRIPTION
This guide covers how to set up various parts of the environment that
are automatically configured for FB engineers; it's not useful for them.

Test plan:

- opened page on localhost, saw nothing
- deleted `isNotFbViewer` class on body, saw text and link
- clicked link, got internal docs