### PR TITLE
Add intro page for the HSL (whoops...), and container cheat sheets

### DIFF
--- a/guides/hack/01-getting-started/04-the-standard-library.md
+++ b/guides/hack/01-getting-started/04-the-standard-library.md
@@ -1,0 +1,30 @@
+## The Hack Standard Library (HSL)
+
+The Hack Standard Library is rapidly evolving, and currently distributed
+separately to HHVM; there are two GitHub projects/composer packages:
+
+- [hhvm/hsl](https://github.com/hhvm/hsl/): The Hack Standard Library
+- [hhvm/hsl-experimental](https://github.com/hhvm/hsl-experimental/):
+  Experimental features, which may be added to the Hack Standard Library in the
+  future
+
+Design goals include:
+- fits well with Hack's type system and overall design
+- internal consistency and predicatability
+- provide building blocks for clear composition instead of many high-level
+  functions
+
+HSL features are grouped by namespace; the namespace indicates the problem area,
+or - if more fine-grained separation is needed - by return type. For example:
+
+- `HH\Lib\Str` contains functions for interacting with strings, such as
+  `Str\contains()`
+- `HH\Lib\Dict` contains functions that return `dict`s, such as `Dict\map()`
+- `HH\Lib\Vec` contains functions that return `vec`s, such as `Vec\map()`
+- `HH\Lib\C` contains functions that operate on `C`ontainers, but do not
+  return or require a specific kind of container, such as `C\contains()`
+
+For a full list, see [the API reference](/hsl/reference/); there is also
+a table containing common functions for [container manipulation].
+
+[container manipulation]: /hack/built-in-types/arrays#using-dicts-keysets-and-vecs

--- a/guides/hack/11-built-in-types/16-string.md
+++ b/guides/hack/11-built-in-types/16-string.md
@@ -22,44 +22,4 @@ the concatenation of the three string literals and the two `float` property valu
 
 `'('`, `','`, `')'`, `"\$p1 = "`, and `"\n"` are examples of string literals.
 
-Here is a list of library functions for manipulating strings:
-
-Name | Description
------|------------
-`HH\Lib\Str\capitalize` | Returns the string with the first character capitalized
-`HH\Lib\Str\capitalize_words` | Returns the string with all words capitalized
-`HH\Lib\Str\chunk` | Returns a vec containing the string split into chunks of the given size
-`HH\Lib\Str\compare` | Returns < 0 if `$string1` is less than `$string2`, > 0 if `$string1` is greater than $string2, and 0 if they are equal
-`HH\Lib\Str\compare_ci` | Returns < 0 if `$string1` is less than `$string2`, > 0 if `$string1` is greater than `$string2`, and 0 if they are equal (case-insensitive)
-`HH\Lib\Str\contains` | Returns whether the "haystack" string contains the "needle" string
-`HH\Lib\Str\contains_ci` | Returns whether the "haystack" string contains the "needle" string (case-insensitive)
-`HH\Lib\Str\ends_with` | Returns whether the string ends with the given suffix
-`HH\Lib\Str\ends_with_ci` | Returns whether the string ends with the given suffix (case-insensitive)
-`HH\Lib\Str\format` | Given a valid format string (defined by `SprintfFormatString`), return a formatted string using `$format_args`
-`HH\Lib\Str\format_number` | Returns a string representation of the given number with grouped thousands
-`HH\Lib\Str\is_empty` | Returns whether the input is null or the empty string
-`HH\Lib\Str\join` | Returns a string formed by joining the elements of the Traversable with the given `$glue` string
-`HH\Lib\Str\length` | Returns the length of the given string
-`HH\Lib\Str\lowercase` | Returns the string with all alphabetic characters converted to lowercase
-`HH\Lib\Str\pad_left` | Returns the string padded to the total length by appending the `$pad_string` to the left
-`HH\Lib\Str\pad_right` | Returns the string padded to the total length by appending the `$pad_string` to the right
-`HH\Lib\Str\repeat` | Returns the input string repeated `$multiplier` times
-`HH\Lib\Str\replace` | Returns the "haystack" string with all occurrences of `$needle` replaced by `$replacement`
-`HH\Lib\Str\replace_ci` | Returns the "haystack" string with all occurrences of `$needle` replaced by `$replacement` (case-insensitive)
-`HH\Lib\Str\replace_every` | Returns the "haystack" string with all occurrences of the keys of `$replacements` replaced by the corresponding values
-`HH\Lib\Str\reverse` | Returns the input string reversed
-`HH\Lib\Str\search` | Returns the first position of the "needle" string in the "haystack" string, or null if it isn't found
-`HH\Lib\Str\search_ci` | Returns the first position of the "needle" string in the "haystack" string, or null if it isn't found (case-insensitive)
-`HH\Lib\Str\search_last` | Returns the last position of the "needle" string in the "haystack" string, or null if it isn't found
-`HH\Lib\Str\split` | Returns a vec containing the string split on the given delimiter
-`HH\Lib\Str\slice` | Returns a substring of length `$length` of the given string starting at the `$offset`
-`HH\Lib\Str\strip_prefix` | Returns the string with the given prefix removed, or the string itself if it doesn't start with the prefix
-`HH\Lib\Str\strip_suffix` | Returns the string with the given suffix removed, or the string itself if it doesn't end with the suffix
-`HH\Lib\Str\starts_with` | Returns whether the string starts with the given prefix
-`HH\Lib\Str\starts_with_ci` | Returns whether the string starts with the given prefix (case-insensitive)
-`HH\Lib\Str\trim` | Returns the given string with whitespace stripped from the beginning and end
-`HH\Lib\Str\trim_left` | Returns the given string with whitespace stripped from the left
-`HH\Lib\Str\trim_right` | Returns the given string with whitespace stripped from the right
-`HH\Lib\Str\splice` | Return the string with a slice specified by the offset/length replaced by the given replacement string
-`HH\Lib\Str\to_int` | Returns the given string as an integer, or null if the string isn't numeric
-`HH\Lib\Str\uppercase` | Returns the string with all alphabetic characters converted to uppercase
+Strings are usually manipulated with functions from the `Str\` namespace in the [Hack Standard Library](/hsl/reference/)

--- a/guides/hack/11-built-in-types/22-arrays.md
+++ b/guides/hack/11-built-in-types/22-arrays.md
@@ -1,4 +1,4 @@
-The preferred object types for providing array-like storage and operations are
+The preferred object types for providing container-like storage and operations are
 `vec`, `dict`, and `keyset`.  These supersede the earlier Hack types
 [Vector, Map, and Set](#legacy-vector-map-and-set), and the
 [legacy array](#legacy-array) type inherited from PHP. Additional special types,
@@ -140,7 +140,7 @@ Hack arrays are generally manipulated using the `C\`, `Dict\`, `Keyset\` and `Ve
 | Type Refinement           | `$v is vec<_>`               | `$d is dict<_, _>`             | `$k is keyset<_>`
 | `Awaitable` Consolidation | `Vec\from_async($v)`<span class="fbOnly apiAlias">`Vec\gen($v)`</span> | `Dict\from_async($d)`<span class="fbOnly apiAlias">`Dict\gen($d)`</span> | `Keyset\from_async($x)`<span class="fbOnly apiAlias">`Keyset\gen($x)`</span>
 
-`$container` can be a `dict`, `keyset`, `vec`, or one of the legacy types of collections described below.
+`$container` can be a `dict`, `keyset`, `vec`, or one of the legacy types of containers described below.
 
 ## Legacy Vector, Map, and Set
 
@@ -223,7 +223,7 @@ The available runtime options change frequently; to get an up-to-date list, sear
   hard to use, but will likely become more useful in the future, as these
   functions are migrated.
 
-## Converting to legacy containers and PHP arrays
+## Converting to legacy collections and PHP arrays
 
 | Converting    | To `Vector`              | To `Map`      | To `Set`              | To `varray`          | To `darray`
 | ----------    | -----------              | --------      | --------              | ----------           | ------

--- a/guides/hack/11-built-in-types/22-arrays.md
+++ b/guides/hack/11-built-in-types/22-arrays.md
@@ -36,39 +36,6 @@ access the key and value for each element.
 
 Elements *cannot* be removed from a vec.
 
-Here is a list of library functions for manipulating a vec:
-
-Name | Description
------|------------
-`HH\Lib\Vec\concat` | Returns a new vec formed by concatenating the given Traversables together
-`HH\Lib\Vec\chunk` | Returns a vec containing the original vec split into chunks of the given size
-`HH\Lib\Vec\diff` | Returns a new vec containing only the elements of the first Traversable that do not appear in any of the other ones
-`HH\Lib\Vec\diff_by` | Returns a new vec containing only the elements of the first Traversable that do not appear in the second one, where an element's identity is determined by the scalar function
-`HH\Lib\Vec\drop` | Returns a new vec containing all except the first `$n` elements of the given Traversable
-`HH\Lib\Vec\fill` | Returns a new vec of size `$size` where all the values are `$value`
-`HH\Lib\Vec\filter` | Returns a new vec containing only the values for which the given predicate returns true
-`HH\Lib\Vec\filter_async` | Returns a new vec containing only the values for which the given async predicate returns true
-`HH\Lib\Vec\filter_nulls` | Returns a new vec containing only non-null values of the given Traversable
-`HH\Lib\Vec\filter_with_key` | Returns a new vec containing only the values for which the given predicate returns true
-`HH\Lib\Vec\flatten` | Returns a new vec formed by joining the Traversable elements of the given Traversable
-`HH\Lib\Vec\from_async` | Returns a new vec containing the awaited result of the given Awaitables
-`HH\Lib\Vec\intersect` | Returns a new vec containing only the elements of the first Traversable that appear in all the other ones
-`HH\Lib\Vec\keys` | Returns a new vec containing the keys of the given KeyedTraversable
-`HH\Lib\Vec\map` | Returns a new vec where each value is the result of calling the given function on the original value
-`HH\Lib\Vec\map_async` | Returns a new vec where each value is the result of calling the given async function on the original value
-`HH\Lib\Vec\map_with_key` | Returns a new vec where each value is the result of calling the given function on the original key and value
-`HH\Lib\Vec\partition` | Returns a 2-tuple containing vecs for which the given predicate returned true and false, respectively
-`HH\Lib\Vec\range` | Returns a new vec containing the range of numbers from `$start` to `$end` inclusive, with the step between elements being `$step` if provided, or `1` by default
-`HH\Lib\Vec\reverse` | Returns a new vec with the values of the given Traversable in reversed order
-`HH\Lib\Vec\sample` | Returns a new vec containing an unbiased random sample of up to $sample_size elements (fewer iff `$sample_size` is larger than the size of `$traversable`)
-`HH\Lib\Vec\shuffle` | Returns a new vec with the values of the given Traversable in a random order
-`HH\Lib\Vec\slice` | Returns a new vec containing the subsequence of the given Traversable determined by the offset and length
-`HH\Lib\Vec\sort` | Returns a new vec sorted by the values of the given Traversable
-`HH\Lib\Vec\sort_by` | Returns a new vec sorted by some scalar property of each value of the given Traversable, which is computed by the given function
-`HH\Lib\Vec\take` | Returns a new vec containing the first `$n` elements of the given Traversable
-`HH\Lib\Vec\unique` | Returns a new vec containing each element of the given Traversable exactly once
-`HH\Lib\Vec\unique_by` | Returns a new vec containing each element of the given Traversable exactly once, where uniqueness is determined by calling the given scalar function on the values
-
 ## dict
 
 While a vec always has a key type of int, a dict (short for dictionary) requires the key type to be specified. As the number of elements in a
@@ -111,49 +78,6 @@ the key and value for each element.
 
 To remove an element from a dict, use `unset`.
 
-Here is a list of library functions for manipulating a dict:
-
-Name | Description
------|------------
-`HH\Lib\Dict\associate` | Returns a new dict where each element in `$keys` maps to the corresponding element in $values
-`HH\Lib\Dict\chunk` | Returns a vec containing the original dict split into chunks of the given size
-`HH\Lib\Dict\count_values` | Returns a new dict mapping each value to the number of times it appears in the given Traversable
-`HH\Lib\Dict\diff_by_key` | Returns a new dict containing only the entries of the first KeyedTraversable whose keys do not appear in any of the other ones
-`HH\Lib\Dict\drop` | Returns a new dict containing all except the first `$n` entries of the given KeyedTraversable
-`HH\Lib\Dict\equal` | Returns whether the two given dicts have the same entries, using strict equality
-`HH\Lib\Dict\fill_keys` | Returns a new dict where all the given keys map to the given value
-`HH\Lib\Dict\filter` | Returns a new dict containing only the values for which the given predicate returns true
-`HH\Lib\Dict\filter_async` | Returns a new dict containing only the values for which the given async predicate returns true
-`HH\Lib\Dict\filter_keys` | Returns a new dict containing only the keys for which the given predicate returns true
-`HH\Lib\Dict\filter_nulls` | Given a KeyedTraversable with nullable values, returns a new dict with those entries removed
-`HH\Lib\Dict\filter_with_key` | Just like filter, but your predicate can include the key as well as the value
-`HH\Lib\Dict\filter_with_key_async` | Like `filter_async`, but lets you utilize the keys of your dict too
-`HH\Lib\Dict\flatten` | Returns a new dict formed by merging the KeyedTraversable elements of the given Traversable
-`HH\Lib\Dict\flip` | Returns a new dict keyed by the values of the given KeyedTraversable and vice-versa
-`HH\Lib\Dict\from_async` | Returns a new dict containing the awaited result of the given Awaitables
-`HH\Lib\Dict\from_entries` | Returns a new dict where each mapping is defined by the given key/value tuples
-`HH\Lib\Dict\from_keys` | Returns a new dict where each value is the result of calling the given function on the corresponding key
-`HH\Lib\Dict\from_keys_async` | Returns a new dict where each value is the result of calling the given async function on the corresponding key
-`HH\Lib\Dict\from_values` | Returns a new dict keyed by the result of calling the given function on each corresponding value
-`HH\Lib\Dict\group_by` | Returns a new dict where keys are the results of the given function called on the given values
-`HH\Lib\Dict\map` | Returns a new dict where each value is the result of calling the given function on the original value
-`HH\Lib\Dict\map_async` | Returns a new dict where each value is the result of calling the given async function on the original value
-`HH\Lib\Dict\map_keys` | Returns a new dict where each key is the result of calling the given function on the original key
-`HH\Lib\Dict\map_with_key` | Returns a new dict where each value is the result of calling the given function on the original value and key
-`HH\Lib\Dict\merge` | Merges multiple KeyedTraversables into a new dict
-`HH\Lib\Dict\partition` | Returns a 2-tuple containing dicts for which the given predicate returned `true` and `false`, respectively
-`HH\Lib\Dict\partition_with_key` | Returns a 2-tuple containing dicts for which the given keyed predicate returned `true` and `false`, respectively
-`HH\Lib\Dict\pull` | Returns a new dict where: values are the result of calling `$value_func` on the original value keys are the result of calling `$key_func` on the original value
-`HH\Lib\Dict\pull_with_key` | Returns a new dict where: values are the result of calling `$value_func` on the original value/key keys are the result of calling `$key_func` on the original value/key
-`HH\Lib\Dict\reverse` | Returns a new dict with the original entries in reversed iteration order
-`HH\Lib\Dict\select_keys` | Returns a new dict containing only the keys found in both the input container and the given Traversable
-`HH\Lib\Dict\sort` | Returns a new dict sorted by the values of the given KeyedTraversable
-`HH\Lib\Dict\sort_by` | Returns a new dict sorted by some scalar property of each value of the given KeyedTraversable, which is computed by the given function
-`HH\Lib\Dict\sort_by_key` | Returns a new dict sorted by the keys of the given KeyedTraversable
-`HH\Lib\Dict\take` | Returns a new dict containing the first `$n` entries of the given KeyedTraversable
-`HH\Lib\Dict\unique` | Returns a new dict in which each value appears exactly once
-`HH\Lib\Dict\unique_by` | Returns a new dict in which each value appears exactly once, where the value's uniqueness is determined by transforming it to a scalar via the given function
-
 ## keyset
 
 A keyset is a data structure that contains an ordered collection of zero or more elements whose values are the keys. And as array keys must have
@@ -193,208 +117,78 @@ To check membership in a keyset, use `C\contains` or `C\contains_key`. To remove
 
 Similar to `dict`, the order of the elements in a keyset is the order in which the elements were inserted.
 
-Here is a list of library functions for manipulating keysets:
+## Using dicts, keysets, and vecs
 
-Name | Description
------|------------
-`HH\Lib\Keyset\chunk` | Returns a vec containing the given Traversable split into chunks of the given size
-`HH\Lib\Keyset\diff` | Returns a new keyset containing only the elements of the first Traversable that do not appear in any of the other ones
-`HH\Lib\Keyset\drop` | Returns a new keyset containing all except the first `$n` elements of the given `Traversable
-`HH\Lib\Keyset\equal` | Returns whether the two given keysets have the same elements, using strict equality
-`HH\Lib\Keyset\filter` | Returns a new keyset containing only the values for which the given predicate returns `true`
-`HH\Lib\Keyset\filter_async` | Returns a new keyset containing only the values for which the given async predicate returns `true`
-`HH\Lib\Keyset\filter_nulls` | Returns a new keyset containing only non-null values of the given Traversable
-`HH\Lib\Keyset\filter_with_key` | Returns a new keyset containing only the values for which the given predicate returns `true`
-`HH\Lib\Keyset\flatten` | Returns a new keyset formed by joining the values within the given Traversables into a keyset
-`HH\Lib\Keyset\from_async` | Returns a new keyset containing the awaited result of the given Awaitables
-`HH\Lib\Keyset\intersect` | Returns a new keyset containing only the elements of the first Traversable that appear in all the other ones
-`HH\Lib\Keyset\keys` | Returns a new keyset containing the keys of the given KeyedTraversable, maintaining the iteration order
-`HH\Lib\Keyset\map` | Returns a new keyset where each value is the result of calling the given function on the original value
-`HH\Lib\Keyset\map_async` | Returns a new keyset where the value is the result of calling the given async function on the original values in the given traversable
-`HH\Lib\Keyset\map_with_key` | Returns a new keyset where each value is the result of calling the given function on the original key and value
-`HH\Lib\Keyset\partition` | Returns a 2-tuple containing keysets for which the given predicate returned `true` and `false`, respectively
-`HH\Lib\Keyset\sort` | Returns a new keyset sorted by the values of the given Traversable
-`HH\Lib\Keyset\take` | Returns a new keyset containing the first `$n` elements of the given Traversable
-`HH\Lib\Keyset\union` | Returns a new keyset containing all of the elements of the given Traversables
+Hack arrays are generally manipulated using the `C\`, `Dict\`, `Keyset\` and `Vec\` functions from the [Hack Standard Library](/hsl/reference); the most common operations are:
+
+| Operation                 | `vec`                        | `dict`                         | `keyset`
+| ---------                 | -----                        | ------                         | --------
+| Initialize empty          | `$v = vec[];`                | `$d = dict[];`                 | `$k = keyset[];`
+| Literal                   | `$v = vec[1, 2, 3];`         | `$d = dict['foo' => 1];`       | `$k = keyset['foo', 'bar'];`
+| From Another Container*   | `$v = vec($container);`      | `$d = dict($keyed_container);` | `$k = keyset($container);`
+| Keys from Container*      | `$v = Vec\keys($container);` | N/A                            | `$k = Keyset\keys($container);`
+| Add Elements              | `$v[] = 4;`                  | `$d['baz'] = 2;`               | `$k[] = 'baz';`
+| Bulk Add Elements         | `$v = Vec\concat($t1, $t2)`  | `$d = Dict\merge($kt1, $kt2)`  | `$k = Keyset\union($t1, $t2)`
+| Remove Elements           | `$v = Vec\concat(Vec\take($t1, $n), Vec\drop($t1, $n + 1)` | `unset($d['baz']);` | `unset($k['baz']);`
+| Key Existence             | `C\contains_key($v, 1)`      | `C\contains_key($d, 'foo')`    | `C\contains_key($k, 'foo')`
+| Value Existence           | `C\contains($v, 3)`          | `C\contains($d, 2)`            | N/A
+| Get or default            | `idx($v, 0, 999)`            | `idx($d, 'foo', 'default')`    | N/A
+| Equality (Order-Dependent) | `$v1 === $v2`               | `$d1 === $d2`                  | `$k1 === $k2`
+| Equality (Order-Independent) | N/A                       | `Dict\equal($d1, $d2)`         | `Keyset\equal($k1, $k2)`
+| Count Elements (i.e., length, size of array) | `C\count($v)` | `C\count($d)`              | `C\count($k)`
+| Type Signature            | `vec<Tv>`                    | `dict<Tk, Tv>`                 | `keyset<Tk>`
+| Type Refinement           | `$v is vec<_>`               | `$d is dict<_, _>`             | `$k is keyset<_>`
+| `Awaitable` Consolidation | `Vec\from_async($v)`<span class="fbOnly apiAlias">`Vec\gen($v)`</span> | `Dict\from_async($d)`<span class="fbOnly apiAlias">`Dict\gen($d)`</span> | `Keyset\from_async($x)`<span class="fbOnly apiAlias">`Keyset\gen($x)`</span>
+
+`$container` can be a `dict`, `keyset`, `vec`, or one of the legacy types of collections described below.
 
 ## Legacy Vector, Map, and Set
 
+**These container types should be avoided in new code.**
+
 Early in Hack's life, the library provided mutable and immutable generic class types called: `Vector`, `ImmVector`, `Map`, `ImmMap`, `Set`,
 and `ImmSet`. However, these have been replaced by `vec`, `dict`, and `keyset`, whose use is recommended in all new code. Each generic type
-had a corresponding literal form. For example, a variable of type `vector<int>` might be initialized using `Vector {22, 33, $v}`, where `$v`
+had a corresponding literal form. For example, a variable of type `Vector<int>` might be initialized using `Vector {22, 33, $v}`, where `$v`
 is a variable of type `int`.
 
-## Legacy array
+`Vector`s, `Map`s and `Set`s are generally interacted with via instance methods on the classes.
 
-**`array` is a hold-over type from PHP. Due to some of the limitations of this type, Hack programmers are encouraged to use `vec`, `dict`,
-and `keyset` instead.**
+| Operation                 | `Vector`                    | `Map`                    | `Set`
+| ---------                 | -----                       | ------                   | --------
+| Initialize empty          | `$v = Vector {};`           | `$m = Map {};`           | `$s = Set {};`
+| Literal                   | `$v = Vector {1, 2, 3};`    | `$m = Map {'foo' => 1};` | `$s = Set {'foo', 'bar'};`
+| Add Elements              | `$v[] = 4;`                 | `$m['baz'] = 2;`         | `$s[] = 'baz';`
 
-Within this section, the term *array* means *legacy array*.
+## PHP arrays: array, varray and darray
 
-Note: Legacy arrays are quite different to arrays in numerous mainstream languages. Specifically, legacy array elements need not have the
-same type, the subscript index need not be an integer (so there is no concept of a base index of zero or one), and there is no concept of
-consecutive elements occupying physically adjacent memory locations.
+**These container types should not be used in new code, and we aim to remove them from the language**
 
-An array is a data structure that contains a collection of zero or more elements whose values are each accessed through a corresponding key.
-As the number of elements in an array can change at runtime, an array type does *not* include an element count.  Consider the following class
-property, which has an array type:
+An `array` is a legacy container type inherited from PHP; it can represent a keyed container (`array<Tk, Tv>` like `dict<Tk, Tv>`) or
+an unkeyed container (`array<Tv>` like `vec<Tv>`) - or these behaviors can be mixed, or unspecified (`array` without generics).
 
-```Hack
-private array<string> $colorsVect = array("red", "white", "blue");
-```
+We aim to remove `array` from the language by making it practical to replace `array`s with either `vec` or `dict`; the current recommended
+approach is:
 
-This is a *vector-like* array, and it has an implicit key type of `int`, and an explicit value type of `string`.  This array is created
-and initialized using the array-creation intrinsic function, `array(...)`.  (There is an equivalent array-creation operator `[...]`.)
-There are three elements, and their corresponding keys are 0, 1, and 2.
+1. identify which `array`s should probably be `vec`s and which should be `dict`s
+2. mark these with the special types `varray<T>` and `darray<Tk, Tv>`
+3. use runtime logging to locate when a `varray` is used like a keyed container and when a `darray` is used like an unkeyed container (e.g. when appended to)
+4. gradually make `varray` behave more like `vec` and `darray` behave more like `dict`
+5. remove the `varray` type when it behaves identically to `vec`, and remove the `darray` type when it behaves identically to `dict`
 
-An array's key type can be declared explicitly; for example:
+| Operation                 | `varray`                | `darray`
+| ---------                 | -----                   | ------
+| Initialize empty          | `$v = varray[];`        | `$m = darray[];`
+| Literal                   | `$v = varray[1, 2, 3];` | `$m = darray['foo' => 1];`
+| Add Elements              | `$v[] = 4;`             | `$m['baz'] = 2;`
 
+### Runtime options
 
-```Hack
-private array<int, string> $colorsMap = array("red", "white", "blue");
-```
+By default, `varray` and `darray` are interchangeable at runtime; this can be changed, as can some legacy PHP array behaviors, depending on the HHVM version.
 
-This is a *map-like* array, with an explicit key and value type.  As before, there are three elements, and their corresponding keys are 0, 1, and 2.
-
-Note, carefully, that although `$colorsVect` and `$colorsMap` result in arrays of `int`/`string` pairs, they do *not* have the same (or
-even compatible) types!
-
-When we create a map-like array, we can specify the key values as well; for example:
-
-```Hack
-private array<int, string> $colorsMap
-  = array(-10 => "white", 12 => "blue", 0 => "red");
-```
-
-Note how the key values do not start at 0, nor are they consecutive!
-
-The key type can be other than `int`; for example:
-
-```Hack
-private array<string, int> $fruitMap = array('oranges' => 25, 'apples' => 12, 'pears' => 17);
-```
-
-Although we can use any type as an array's key type, behind the scenes, the key is actually represented as an `int` or `string`,
-so&mdash;possibly surprising, or at least, unexpected&mdash;conversions occur when other key types are specified. **Programmers are strongly
-advised to avoid using key types other than `int` or `string`.**
-
-Each element in an array must have a value type that is the exact type indicated by the array declaration, or a
-[subtype](../types/supertypes-and-subtypes.md) of that type. For example:
-
-```Hack
-private array<num> $numbers = array(5.4, 234);
-private array<mixed> $misc = array(10, 'b', false);
-```
-
-The vector-like array `$numbers` has type `num` and contains a `float` and an `int`, respectively.  The vector-like array `$misc` has type `mixed`,
-and contains an `int`, a `string`, and a `bool`, respectively.
-
-An array element can have any type (which allows for arrays of arrays).  For example:
-
-```Hack
-private array<array<int>> $counts = array(array(10,20), array(2,3));
-```
-
-`$counts` is a vector-like array of two elements each of which is a vector-like array of two elements, each of which is an `int`.
-
-An array is represented as an ordered map in which each entry is a key/value pair that represents an element. Duplicate keys are not permitted.
-The order of the elements in the map is the order in which the elements were inserted into the array. An element is said to *exist* once it has
-been inserted into the array with a corresponding key. An array is *extended* by initializing a previously non-existent element using a new key.
-
-Elements can be removed from an array with `unset`.
-
-The [`foreach` statement](../statements/foreach.md) can be used to iterate over the collection of elements in an array, in the order in
-which the elements were inserted. This statement provides a way to access the key and value for each element.
-
-The value (and possibly the type) of an existing element is obtained or changed, and new elements are inserted, using the
-[subscript operator `[]`](../expressions-and-operators/subscript.md).  For example:
-
-@@ arrays-examples/legacy-array-colors.php @@
-
-@@ arrays-examples/legacy-array-fruits.php @@
-
-Two arrays can be compared using [relational operators](../expressions-and-operators/relational.md) and
-[equality operators](../expressions-and-operators/equality.md).
-
-Numerous library functions are available that manipulate arrays.
-
-## Migrating from legacy arrays
-
-Two special types, `varray` and `darray`, currently exist to facilitate
-migration from the legacy `array` type towards a more type-safe codebase (note
-that both legacy `array` and these migration types are temporary, the plan is
-for all of them to be removed from the Hack language eventually).
-
-While migrating straight to `vec` and `dict` would be preferable (and may be
-possible for smaller projects), it is usually not possible without manual review
-and testing of the changes. In contrast, `varray` and `darray` are designed to
-be drop-in replacements for the `array` type, so an automated migration is
-feasible.
-
-In general, `array`, `varray` and `darray` can be used interchangeably at
-runtime (which makes such automated migration safe), but they are recognized as
-different types by the typechecker&mdash;resulting in a more type-safe codebase.
-See below for a more detailed description.
-
-### Usage
-
-`varray` represents a &ldquo;vec-like array&rdquo; and must always be used with
-a single generic type parameter (e.g. `varray<int>`, `varray<MyClass>`,
-`varray<mixed>`). `darray` represents a &ldquo;dict-like array&rdquo; and must
-be used with two generic type parameters, the first being a valid key type
-(`int`, `string` or `arraykey`), e.g. `darray<string, MyClass>` or
-`darray<arraykey, mixed>`.
-
-Values can be initialized using literals:
-
-```Hack
-$numbers = varray[1, 1, 2, 3, 5, 8, 14];
-$words = varray['foo', 'bar'];
-$options = darray['yes' => 1, 'no' => 2];
-```
-
-Or from values of any other array-like types:
-
-```Hack
-$vee = varray($traversable);
-$dee = darray($keyed_traversable);
-```
-
-(not to be confused with `array('foo', 'bar')`, where rounded brackets are used
-for literal values)
-
-### Runtime behavior
-
-- At runtime, all `array`, `varray` and `darray` values are mutually compatible,
-  so there is no risk of causing a breaking change by migrating between them.
-- Note that this means that `varray` and `darray` preserve all quirks of legacy
-  arrays (such as their &ldquo;magical&rdquo; conversions between key types).
-  This is why migrating to `vec` and `dict` would be preferable, but is not
-  backwards-compatible.
-- The built-in function `\is_array()` returns `true` for all three types (again,
-  preserving backwards-compatibility).
-
-### Typechecker behavior
-
-- As of HHVM 4.28, the typechecker treats `array<T>` (`array` with one generic
-  type parameter) as an alias of `varray<T>`, and `array<Tk, Tv>` (with two
-  generic type parameters) as an alias of `darray<Tk, Tv>`. This means that the
-  typechecker output will always show `varray`/`darray` in error messages, even
-  for code that uses `array`s.
-- There is one additional special type, only recognized by the typechecker (does
-  not exist at runtime): `array` with missing generic type parameters is
-  considered a `varray_or_darray`, which is, roughly, treated as a supertype of
-  both `varray` and `darray` (`varray`/`darray` can be used where
-  `varray_or_darray` is expected but not vice-versa).
-- `varray_or_darray` can be used as a typehint (for example, when an automated
-  migration can't reliably determine whether `varray` or `darray` is correct),
-  but there is no literal syntax.
-- There is special handling for empty `array` literals (`array()` or `[]`) in
-  the typechecker&mdash;generally, they're allowed everywhere any of the above
-  types is used.
-- Note that these rules don't apply to HHVM versions prior to 4.28. Previously,
-  the typechecker recognized `array`, `varray`, `darray` and `varray_or_darray`
-  as separate types that couldn't always be used interchangeably.
+The available runtime options change frequently; to get an up-to-date list, search `ini_get_all()` for settings beginning with `hhvm.hack_arr`; in general:
+- a value of `0` means no logging
+- `1` means a warning or notice is raised
+- `2` means a recoverable error is raised
 
 ### `.hhconfig` options
 
@@ -409,3 +203,13 @@ for literal values)
   because of various `array` typehints in built-in functions, which makes it
   hard to use, but will likely become more useful in the future, as these
   functions are migrated.
+
+## Converting to legacy containers and PHP arrays
+
+| Converting    | To `Vector`              | To `Map`      | To `Set`              | To `varray`          | To `darray`
+| ----------    | -----------              | --------      | --------              | ----------           | ------
+| `dict`        | N/A                      | `new Map($d)` | N/A                   | N/A                  | `darray($d)`
+| `dict` keys   | `Vector::fromKeysOf($d)` | N/A           | `Set::fromKeysOf($d)` | `array_keys($d)`<span class="fbOnly apiAlias">`PHP\array_keys($d)`</span> | N/A
+| `dict` values | `new Vector($d)`         | N/A           | `new Set($d)`         | `varray($d)`         | N/A
+| `vec`         | `new Vector($v)`         | `new Map($v)` | `new Set($v)`         | `varray($v)`         | `darray($v)`
+| `keyset`      | `new Vector($k)`         | `new Map($k)` | `new Set($k)`         | `varray($k)`         | `darray($k)`


### PR DESCRIPTION
- doesn't look like we actually had a page saying what the HSL is...
  whoops.
- replace hardcoded lists of functions with:
  - link to generated API references
  - less in-depth but more usable 'cheat sheets' from internal docs

`fbOnly` spans are visible if either:
- you are on FB corpnet
- you delete the `isNotFBViewer` class from `<body>`