### PR TITLE
XOR is not a valid operator | Remove XOR from spec

### DIFF
--- a/guides/hack/15-asynchronous-operations/37-await-as-an-expression-spec.md
+++ b/guides/hack/15-asynchronous-operations/37-await-as-an-expression-spec.md
@@ -75,7 +75,6 @@ Valid positions:
     * Null Coalescing Assignment is both, so it doesn't allow either:
         * `??=`: `(await $no) ??= (await $no)`
     * Binary operators that allow await in both positions:
-        * `XOR`: `(await $yes) XOR (await $yes)`
         * `+`: `(await $yes) + (await $yes)`
         * `-`: `(await $yes) - (await $yes)`
         * `*`: `(await $yes) * (await $yes)`


### PR DESCRIPTION
Remove the use of the PHP XOR operator in 37-await-as-an-expression-spec.md.