### PR TITLE
Remove throwaway mentions of instanceof

### DIFF
--- a/guides/hack/03-expressions-and-operators/01-introduction.md
+++ b/guides/hack/03-expressions-and-operators/01-introduction.md
@@ -28,7 +28,6 @@
 * [Function-call, `()`](function-call.md)
 * [Grouping of terms](some-basics.md)
 * [Increment, `++`](incrementing-and-decrementing.md)
-* [instanceof](instanceof.md)
 * [invariant intrinsic function](invariant.md)
 * [is](is.md)
 * [Lambda creation](lambda-creation.md)

--- a/guides/hack/03-expressions-and-operators/07-operator-precedence.md
+++ b/guides/hack/03-expressions-and-operators/07-operator-precedence.md
@@ -4,7 +4,7 @@ Operator | Associativity
 ------------ | ---------
 `new`  | none
 `()   []   ->   ?->   ++   --   **` | Left to Right
-`instanceof   is   as   ?as` | none
+`is   as   ?as` | none
 `!   ~   +   -   ++   --   (`*type*`)   @   await`	| Right to Left
 `*   /   %`	| Left to Right
 `+   -   .`	| Left to Right

--- a/guides/hack/03-expressions-and-operators/53-instanceof.md
+++ b/guides/hack/03-expressions-and-operators/53-instanceof.md
@@ -1,4 +1,5 @@
 **The use of `instanceof` has been deprecated; use operator [`is`](is.md) instead.**
+**It does NOT exist in HHVM 4.15 and up and will result in a parse error.**
 
 Operator `instanceof` determines if the variable designated by its left-hand operand is an object having the type specified by the right-hand
 one.  It returns a `bool` result.  For example:

--- a/guides/hack/03-expressions-and-operators/55-is.md
+++ b/guides/hack/03-expressions-and-operators/55-is.md
@@ -1,7 +1,7 @@
 Operator `is` determines if the value designated by its left-hand operand has the type specified by the right-hand one.  The operator returns a `bool` result.  The
 operator [refines](../types/type-refinement.md) the type of its left-hand operand when used in an `if` statement, `invariant`, or ternary expression.
 
-Operator `is` should be used instead of `instanceof` or calls to library functions like `is_bool`, `is_int`, and so on.
+Operator `is` should be used instead of calls to library functions like `is_bool`, `is_int`, and so on.
 
 For example:
 

--- a/guides/hack/12-generics/19-type-erasure.md
+++ b/guides/hack/12-generics/19-type-erasure.md
@@ -12,9 +12,9 @@ type erasure at runtime. A type parameter T *cannot* be used in the following si
  * Creating instances using `new` (e.g., `new T()`).
  * Casting (e.g., `(T) $value`).
  * In a class scope, e.g., `T::aStaticMethod()`.
- * As the right-hand side of an `instanceof` or `is` check.
+ * As the right-hand side of an `is` check.
  * As the type of a static property.
  * As the type of the exception in a catch block (e.g., `catch (T $exception)`).
 
-For a possible alternative to instantiation, class scope and `instanceof` usage, Hack provides a construct called
+For a possible alternative to instantiation and class scope Hack provides a construct called
 [`Classname<T>`](../built-in-types/classname.md) that extends the PHP representation of `Foo::class`.

--- a/guides/hack/15-asynchronous-operations/37-await-as-an-expression-spec.md
+++ b/guides/hack/15-asynchronous-operations/37-await-as-an-expression-spec.md
@@ -17,7 +17,6 @@ Valid positions:
     * CastExpression: `(<token>)(await $yes)`
     * MemberSelectionExpression: `(await $yes)->(await $yes)`
     * ScopeResolutionExpression: `(await $yes)::(await $yes)`
-    * InstanceofExpression: `(await $yes) instanceof (await $yes)`
     * IsExpression: `(await $yes) is Int`
     * AsExpression: `(await $yes) as Int`
     * NullableAsExpression: `(await $yes) ?as Int`

--- a/guides/hack/21-XHP/10-interfaces.md
+++ b/guides/hack/21-XHP/10-interfaces.md
@@ -15,7 +15,7 @@ XHP presents a tree structure, and this interface defines what can be valid chil
  - arrays of any of the above
 
 Despite strings, integers, floats, and arrays not being objects, both the typechecker and HHVM consider them to implement this interface,
-for parameter/return types and for `instanceof`/`is` checks.
+for parameter/return types and for `is` checks.
 
 ## Advanced Interfaces
 


### PR DESCRIPTION
It was removed in hhvm 4.15.
It is still a keyword (in the runtime and in keywords.md).
The article instanceof.md still exists.
It has a big deprecation warning on top.
This might be worth removing too @reviewer.
_Edit: Sorry, I did not expect `@reviewer` to be an actual user._