### PR TITLE
better Composer instructions

### DIFF
--- a/guides/hack/01-getting-started/03-starting-a-real-project.md
+++ b/guides/hack/01-getting-started/03-starting-a-real-project.md
@@ -4,7 +4,7 @@ Real projects generally aren't a single file in isolation; they tend to have
 dependencies such as the [Hack Standard Library], and various optional tools.
 
 A good starting point is to:
-- [install Composer]
+- [install Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos)
 - create an empty `.hhconfig` file
 - create `src/` and `tests/` subdirectories
 - configure autoloading
@@ -17,7 +17,13 @@ Currently, HHVM needs to be given a map of what files define which classes,
 functions and so on - for example, to execute the code `new Foo()`, HHVM needs
 to know that the class `Foo` is defined in `src/Foo.hack`.
 
-[hhvm-autoload] generates this map, using an `hh_autoload.json` configuration
+[hhvm-autoload] generates this map. To add it to your project, run:
+
+```
+$ php /path/to/composer.phar require hhvm/hhvm-autoload
+```
+
+hhvm-autoload needs an `hh_autoload.json` configuration
 file. For most projects, a minimal example is:
 
 ```JSON

--- a/guides/hack/01-getting-started/03-starting-a-real-project.md
+++ b/guides/hack/01-getting-started/03-starting-a-real-project.md
@@ -4,7 +4,7 @@ Real projects generally aren't a single file in isolation; they tend to have
 dependencies such as the [Hack Standard Library], and various optional tools.
 
 A good starting point is to:
-- [install Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos)
+- [install Composer]
 - create an empty `.hhconfig` file
 - create `src/` and `tests/` subdirectories
 - configure autoloading
@@ -334,4 +334,4 @@ Hack which change frequently.
 [HHAST]: https://github.com/hhvm/hhast
 [Hack Standard Library]: https://github.com/hhvm/hsl/
 [hhvm-autoload]: https://github.com/hhvm/hhvm-autoload
-[install Composer]: https://getcomposer.org/download/
+[install Composer]: https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos


### PR DESCRIPTION
Fixes #790

The GitHub hhvm-autoload page has the installation instructions, but it seems reasonable to also have a short version here like #790 suggested.

I'm not sure what the best `composer` command syntax is since it depends on how you installed it, I used `php /path/to/composer.phar` since it seemed like the most descriptive and generic option. The other examples below just use `composer` which I think is fine, since by then the reader will have figured out how to invoke it correctly.