### PR TITLE
remove unnecessary (I think?) CSS flexbox

### DIFF
--- a/sass/layout.scss
+++ b/sass/layout.scss
@@ -5,9 +5,6 @@
 }
 
 .flexWrapper {
-  align-items: flex-start;
-  display: flex;
-  flex-flow: row nowrap;
   padding-bottom: 50px;
   padding-top: 50px;
 }
@@ -25,8 +22,6 @@
 }
 
 .mainWrapper {
-  flex: 1;
-  order: 2;
   max-width: $default-max-width;
 }
 
@@ -55,10 +50,6 @@
   body {
     display: flex;
     flex-flow: column wrap;
-  }
-
-  .flexWrapper {
-    display: block;
   }
 
   .mainContainer {


### PR DESCRIPTION
Fixes #797

I don't see any reason for this flexbox, it only wraps 1 element (maybe there were more in the past...?)

Removing it avoids the issues from #797, I tested with all the different browser widths which we support, in Firefox and Chromium.