### PR TITLE
Remove HH_FIXME's that are not needed anymore

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,16 +11,17 @@ async function site_main_async(): Awaitable<noreturn> {
   // header is of the form HOST:PORT - for `parse_url`, we need
   // `http://HOST:port/` as `parse_url()` is unable to parse IPv6
   // strings like `[::1]:8080
-  /* HH_FIXME[2050] $_SERVER */
-  $dummy_uri = 'http://'.$_SERVER['HTTP_HOST'].'/';
+
+  $server = HHVM\UserDocumentation\_Private\SuperGlobals\server_variables();
+  $dummy_uri = 'http://'.$server['HTTP_HOST'].'/';
   $host = \parse_url($dummy_uri, PHP_URL_HOST);
   $port = \parse_url($dummy_uri, PHP_URL_PORT);
   // We just use this to figure out if we should do a redirect - if we were
   // doing something more important, we should make sure that the remote end
   // is from a local-use IP range.
-  $https = /* HH_FIXME[2050] */ $_SERVER['HTTP_X_FORWARDED_PROTO'] ??
-    /* HH_FIXME[2050] */ $_SERVER['HTTPS'] ??
-    /* HH_FIXME[2050] */ $_SERVER['https'] ??
+  $https = $server['HTTP_X_FORWARDED_PROTO'] ??
+    $server['HTTPS'] ??
+    $server['https'] ??
     false;
   if ($https is string) {
     $https = Str\lowercase((string)$https);

--- a/src/APIIndex.php
+++ b/src/APIIndex.php
@@ -96,11 +96,10 @@ final class APIIndex {
   }
 
   private function getMethods(APIIndexEntry $entry): ?vec<APIMethodIndexEntry> {
-    $arr = Shapes::toArray($entry);
-    $methods = $arr['methods'] ?? null;
+    $methods = $entry['methods'] ?? null;
     if ($methods !== null) {
       return Vec\map(
-        /* HH_IGNORE_ERROR[4110] */ $methods,
+        $methods,
         $method ==> TypeAssert\matches_type_structure(
           type_alias_structure(APIMethodIndexEntry::class),
           $method,

--- a/src/build/RubyDependenciesBuildStep.php
+++ b/src/build/RubyDependenciesBuildStep.php
@@ -40,7 +40,7 @@ final class RubyDependenciesBuildStep extends BuildStep {
       'environment' => dict[
         'GEM_HOME' => $ruby_root,
       ]
-        |> Dict\merge($$, /* HH_FIXME[2050] */ $_ENV),
+        |> Dict\merge($$, _Private\SuperGlobals\environment_variables()),
     );
     if (!\file_exists($bundler)) {
       Log::v("\nInstalling bundler");

--- a/src/build/SASSBuildStep.php
+++ b/src/build/SASSBuildStep.php
@@ -28,7 +28,7 @@ final class SASSBuildStep extends BuildStep {
       'environment' => dict[
         'GEM_HOME' => LocalConfig::ROOT.'/vendor-rb',
       ]
-        |> Dict\merge($$, /* HH_FIXME[2050] */ $_ENV),
+        |> Dict\merge($$, _Private\SuperGlobals\environment_variables()),
     );
     list($exit_code, $stdout, $stderr) = await _Private\execute_async(
       $options,

--- a/src/build/UpdateAutoloaderBuildStep.php
+++ b/src/build/UpdateAutoloaderBuildStep.php
@@ -37,7 +37,9 @@ final class UpdateAutoloaderBuildStep extends BuildStep {
       ->setBuilder($importer)
       ->setRoot(LocalConfig::ROOT)
       ->setRelativeAutoloadRoot($config['relativeAutoloadRoot'])
-      ->setFailureHandler(/* HH_IGNORE_ERROR[4110] */ $handler)
+      ->setFailureHandler(
+        /* HH_IGNORE_ERROR[4110] silent upcast from string to failure handler*/ $handler,
+      )
       ->setIsDev($dev)
       ->writeToDirectory(LocalConfig::ROOT.'/vendor/');
   }

--- a/src/site/controllers/WebController.php
+++ b/src/site/controllers/WebController.php
@@ -104,7 +104,7 @@ abstract class WebController {
   protected static function invariantTo404<T>((function(): T) $what): T {
     try {
       return $what();
-    } catch (/* HH_FIXME[2049] */ \HH\InvariantException $e) {
+    } catch (InvariantException $e) {
       throw new HTTPNotFoundException($e->getMessage(), $e->getCode(), $e);
     }
   }

--- a/src/site/xhp/ui-navbar.php
+++ b/src/site/xhp/ui-navbar.php
@@ -234,7 +234,8 @@ class :ui:navbar extends :x:element {
     $root = <ul class={$list_class} />;
     foreach ($parent['children'] as $child) {
       $root->appendChild(
-        $render_func(/* HH_IGNORE_ERROR[4110] mixed to shape */ $child),
+        /* HH_IGNORE_ERROR[4110] key children is typehinted as mixed to prevent infinite regress */
+        $render_func($child),
       );
     }
     return $root;

--- a/src/typedefs.php
+++ b/src/typedefs.php
@@ -82,6 +82,7 @@ type APIIndexEntry = shape(
   'name' => string,
   'htmlPath' => string,
   'urlPath' => string,
+  ?'methods' => dict<string, APIMethodIndexEntry>,
   ...
 );
 

--- a/src/utils/_private/SuperGlobals.php
+++ b/src/utils/_private/SuperGlobals.php
@@ -1,0 +1,25 @@
+<?hh // strict
+
+namespace HHVM\UserDocumentation\_Private\SuperGlobals;
+
+use namespace Facebook\{TypeAssert, TypeCoerce};
+
+function environment_variables(): dict<string, arraykey> {
+  return TypeAssert\matches<dict<string, arraykey>>(
+    dict(\HH\global_get('_ENV') as KeyedContainer<_, _>),
+  );
+}
+
+/**
+ * This type is very big.
+ * Add the keys that you need.
+ * The more you add, the slower it becomes however.
+ */
+type TServerVarabies = shape(
+  'HTTP_HOST' => string,
+  ...
+);
+
+function server_variables(): TServerVarabies {
+  return TypeCoerce\match<TServerVarabies>(\HH\global_get('_SERVER'));
+}

--- a/src/utils/_private/SuperGlobals.php
+++ b/src/utils/_private/SuperGlobals.php
@@ -2,7 +2,7 @@
 
 namespace HHVM\UserDocumentation\_Private\SuperGlobals;
 
-use namespace Facebook\{TypeAssert, TypeCoerce};
+use namespace Facebook\TypeAssert;
 
 function environment_variables(): dict<string, arraykey> {
   return TypeAssert\matches<dict<string, arraykey>>(
@@ -15,11 +15,11 @@ function environment_variables(): dict<string, arraykey> {
  * Add the keys that you need.
  * The more you add, the slower it becomes however.
  */
-type TServerVarabies = shape(
+type TServerVariables = shape(
   'HTTP_HOST' => string,
   ...
 );
 
-function server_variables(): TServerVarabies {
-  return TypeCoerce\match<TServerVarabies>(\HH\global_get('_SERVER'));
+function server_variables(): TServerVariables {
+  return \HH\global_get('_SERVER') as TServerVariables;
 }

--- a/src/utils/_private/SuperGlobals.php
+++ b/src/utils/_private/SuperGlobals.php
@@ -2,11 +2,11 @@
 
 namespace HHVM\UserDocumentation\_Private\SuperGlobals;
 
-use namespace Facebook\TypeAssert;
+use namespace Facebook\TypeCoerce;
 
-function environment_variables(): dict<string, arraykey> {
-  return TypeAssert\matches<dict<string, arraykey>>(
-    dict(\HH\global_get('_ENV') as KeyedContainer<_, _>),
+function environment_variables(): dict<string, string> {
+  return TypeCoerce\match<dict<string, string>>(
+    \HH\global_get('_ENV'),
   );
 }
 

--- a/src/utils/execute_async.php
+++ b/src/utils/execute_async.php
@@ -6,7 +6,7 @@ use namespace HH\Lib\{Str, Vec};
 
 type SubprocessOptions = shape(
   ?'working_directory' => string,
-  ?'environment' => dict<string, arraykey>,
+  ?'environment' => dict<string, string>,
 );
 
 // A wrapper around the built-in exec with a nicer signature.

--- a/src/utils/execute_async.php
+++ b/src/utils/execute_async.php
@@ -6,7 +6,7 @@ use namespace HH\Lib\{Str, Vec};
 
 type SubprocessOptions = shape(
   ?'working_directory' => string,
-  ?'environment' => dict<string, string>,
+  ?'environment' => dict<string, arraykey>,
 );
 
 // A wrapper around the built-in exec with a nicer signature.

--- a/src/utils/get_fb_ip_ranges.php
+++ b/src/utils/get_fb_ip_ranges.php
@@ -42,8 +42,7 @@ function cidr_to_bitstring_and_bitmask(string $cidr): (string, string) {
 function is_ip_in_range(string $ip, (string, string) $range): bool {
   $addr_bitstring = \inet_pton($ip);
   list($range_bitstring, $range_bitmask) = $range;
-  /* HH_IGNORE_ERROR[4110] bitwise & on strings */
-  /* HH_IGNORE_ERROR[4118] not always-false (=== with 'differing' types) */
+  /* HH_IGNORE_ERROR[4110] bitwise & on strings ($addr_bitstring is TAny) */
   return ($addr_bitstring & $range_bitmask) === $range_bitstring;
 }
 

--- a/src/utils/get_fb_ip_ranges.php
+++ b/src/utils/get_fb_ip_ranges.php
@@ -42,7 +42,9 @@ function cidr_to_bitstring_and_bitmask(string $cidr): (string, string) {
 function is_ip_in_range(string $ip, (string, string) $range): bool {
   $addr_bitstring = \inet_pton($ip);
   list($range_bitstring, $range_bitmask) = $range;
-  /* HH_IGNORE_ERROR[4110] bitwise & on strings ($addr_bitstring is TAny) */
+  /* HH_IGNORE_ERROR[4110] bitwise & on strings
+     Typechecker remains quiet since $addr_bitstring is a TAny
+     but $range_bimask is a string.*/
   return ($addr_bitstring & $range_bitmask) === $range_bitstring;
 }
 

--- a/tests/AutoLinkifyAPITest.php
+++ b/tests/AutoLinkifyAPITest.php
@@ -65,10 +65,8 @@ class AutoLinkifyAPITest extends \Facebook\HackTest\HackTest {
   ): Awaitable<void> {
     list($_page, $body) = await PageLoader::getPageAsync($source);
 
-    /* HH_FIXME[2049] No DOM HHI: facebook/hhvm#5322 */
     $dom = new \DOMDocument();
     $dom->loadHTML($body);
-    /* HH_FIXME[2049] No DOM HHI: facebook/hhvm#5322 */
     $xpath = new \DOMXPath($dom);
 
     $nodes = $xpath->query(

--- a/tests/InternalLinksTest.php
+++ b/tests/InternalLinksTest.php
@@ -99,12 +99,10 @@ final class InternalLinksTest extends \Facebook\HackTest\HackTest {
 
     expect($response->getStatusCode())->toBeSame(200, $page);
 
-    /* HH_FIXME[2049] No DOM HHI: facebook/hhvm#5322 */
     $dom = new \DOMDocument();
     \libxml_use_internal_errors(true); // No support for HTML5 tags
     $dom->loadHTML($body);
     \libxml_clear_errors();
-    /* HH_FIXME[2049] No DOM HHI: facebook/hhvm#5322 */
     $xpath = new \DOMXPath($dom);
     $hrefs = $xpath->query('//a/@href');
 


### PR DESCRIPTION
Also make super globals typesafe.
$_SERVER is a stub of the real type.
Validation of a ginormous shape that we mostly don't use
on every request is just a waste.
$_ENV can be validated fully, since it is only used during the build process.