### PR TITLE
Configuring TravisCI: Add src/ argument to hhast-lint 

### DIFF
--- a/guides/hack/01-getting-started/03-starting-a-real-project.md
+++ b/guides/hack/01-getting-started/03-starting-a-real-project.md
@@ -366,7 +366,7 @@ composer install
 hh_client
 vendor/bin/hacktest tests/
 if !(hhvm --version | grep -q -- -dev); then
-  vendor/bin/hhast-lint
+  vendor/bin/hhast-lint src/
 fi
 ```
 


### PR DESCRIPTION
Just running `vendor/bin/hhast-lint` generates the following output: 

> You must either specify PATH arguments, or provide a configurationfile.

and fails the TravisCI build. By adding `src/` as an argument, this message goes away and the build can then succeed. 