### PR TITLE
Update Docker example to work in hhvm 4.2+

### DIFF
--- a/guides/hhvm/01-installation/04-docker.md
+++ b/guides/hhvm/01-installation/04-docker.md
@@ -27,7 +27,12 @@ EXPOSE 80
 
 ```
 <?hh
-echo "Hello World!";
+
+<<__EntryPoint>>
+function main(): noreturn {
+  echo "Hello World!";
+  exit(0);
+}
 ```
 
 Now in a shell run:


### PR DESCRIPTION
The default mode is strict, which does not allow toplevel code.
We could also fix this by adding a `// partial` comment, but those are slated to be removed.