### PR TITLE
Update directory index caching

### DIFF
--- a/src/build/BuildPaths.php
+++ b/src/build/BuildPaths.php
@@ -12,8 +12,9 @@
 namespace HHVM\UserDocumentation;
 
 abstract final class BuildPaths {
-  const string HHVM_TREE = LocalConfig::ROOT.'/api-sources/hhvm';
-  const string HSL_TREE = LocalConfig::ROOT.'/api-sources/hsl';
+  const string API_SOURCES_DIR = LocalConfig::ROOT.'/api-sources';
+  const string HHVM_TREE = self::API_SOURCES_DIR.'/hhvm';
+  const string HSL_TREE = self::API_SOURCES_DIR.'/hsl';
   const string HSL_EXPERIMENTAL_TREE =
     LocalConfig::ROOT.'/api-sources/hsl-experimental';
 


### PR DESCRIPTION
It currently:
- assumes we are using git submodules. This is no longer the case. This
  makes cache invalidation broken.
- provides opaque paths

Improve both.

```
% ls scratch/dir-index
api-sources_hhvm_hphp_hack_hhi-94a7bf802098a55a1d9a341c74eae55caf0d1bca16dc291953e6a04e016eb1a6.json
api-sources_hhvm_hphp_runtime_ext-94a7bf802098a55a1d9a341c74eae55caf0d1bca16dc291953e6a04e016eb1a6.json
api-sources_hhvm_hphp_system_php-94a7bf802098a55a1d9a341c74eae55caf0d1bca16dc291953e6a04e016eb1a6.json
api-sources_hsl-experimental_src-ed66395507dcb84577eff39c478975a73296ff51f6ee2c31a11a5cee4a7a3bfa.json
api-sources_hsl_src-b1ca54d6b19ad1e6ce0384183a62621949469f90933dc24380764bc0c48ed996.json
```