### PR TITLE
Separate out test commands in travis.yml

### DIFF
--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -ex
-hh_server --check $(pwd)
-vendor/bin/hacktest tests/
-vendor/bin/hhast-lint
-vendor/bin/hh-codegen-verify-signatures src

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ install:
 - docker pull hhvm/hhvm-proxygen:$HHVM_VERSION
 script:
 - docker build -t hhvm/user-documentation:scratch -f .deploy/built-site.Dockerfile .
-- docker run --rm -w /var/www hhvm/user-documentation:scratch ./.travis-test.sh
+- docker run --rm -w /var/www hhvm/user-documentation:scratch hh_server --check .
+- docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hacktest tests/
+- docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hhast-lint
+- docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hh-codegen-verify-signatures src
 deploy:
   provider: script
   script: "./.travis-deploy.sh"


### PR DESCRIPTION
This makes it easier to see which command is producing which output,
and which is failing.