### PR TITLE
[easy] Fix variable name typo in documentation

### DIFF
--- a/guides/hack/03-expressions-and-operators/52-type-assertions.md
+++ b/guides/hack/03-expressions-and-operators/52-type-assertions.md
@@ -40,10 +40,10 @@ an explicit type.
 
 ``` Hack
 function transport(?Car $c): void {
-  if ($v is nonnull) {
-    // Infers that $v is Car, but saves us
+  if ($c is nonnull) {
+    // Infers that $c is Car, but saves us
     // repeating the name of the type.
-    $v->drive();
+    $c->drive();
   }
 }
 ```


### PR DESCRIPTION
This variable is $v in the signature, but $c in the body. Since it's a Car, I consolidated on $c.