### PR TITLE
support for patching hackttp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "facebook/xhp-lib": "^4.0",
         "hhvm": "4.74.*",
-        "usox/hackttp": "dev-master",
+        "usox/hackttp": "^0.5.2",
         "hhvm/hhvm-autoload": "^3.0",
         "hhvm/type-assert": "^4.0",
         "facebook/hack-codegen": "^4.0",
@@ -17,7 +17,10 @@
         "hhvm/hhast": "^4.0",
         "facebook/definition-finder": "^2.0.0",
         "hhvm/hacktest": "^2.0",
-        "usox/hackmock": "dev-master",
         "facebook/fbexpect": "^2.6.1"
+    },
+    "scripts": {
+        "post-install-cmd": "patch --dry-run -R -p1 -i hackttp.patch || patch -p1 -i hackttp.patch",
+        "post-update-cmd": "patch --dry-run -R -p1 -i hackttp.patch || patch -p1 -i hackttp.patch"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d26e5f2a9f61b2cba2aa7cb70015fb17",
+    "content-hash": "e272a40b9102a6a6342a58181cd9c670",
     "packages": [
         {
             "name": "facebook/definition-finder",
@@ -133,16 +133,16 @@
         },
         {
             "name": "facebook/hack-codegen",
-            "version": "v4.3.11",
+            "version": "v4.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hack-codegen.git",
-                "reference": "ac9e8133259858795cee2176675c96f296be5c9d"
+                "reference": "329e87a3deba512e7ee681ab6bb10a2869839460"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hack-codegen/zipball/ac9e8133259858795cee2176675c96f296be5c9d",
-                "reference": "ac9e8133259858795cee2176675c96f296be5c9d",
+                "url": "https://api.github.com/repos/hhvm/hack-codegen/zipball/329e87a3deba512e7ee681ab6bb10a2869839460",
+                "reference": "329e87a3deba512e7ee681ab6bb10a2869839460",
                 "shasum": ""
             },
             "require": {
@@ -190,7 +190,7 @@
                 "code generation",
                 "hack"
             ],
-            "time": "2020-07-15T20:13:12+00:00"
+            "time": "2020-09-21T21:12:16+00:00"
         },
         {
             "name": "facebook/hack-http-request-response-interfaces",
@@ -353,16 +353,16 @@
         },
         {
             "name": "facebook/hh-clilib",
-            "version": "v2.5.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hh-clilib.git",
-                "reference": "5b914cb3a0b84d6476393ff7f04812b24d7163f8"
+                "reference": "17b7ceffa24d9ed5dce4145025e3dea476ff6d88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/5b914cb3a0b84d6476393ff7f04812b24d7163f8",
-                "reference": "5b914cb3a0b84d6476393ff7f04812b24d7163f8",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/17b7ceffa24d9ed5dce4145025e3dea476ff6d88",
+                "reference": "17b7ceffa24d9ed5dce4145025e3dea476ff6d88",
                 "shasum": ""
             },
             "require": {
@@ -387,7 +387,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2020-07-07T20:34:32+00:00"
+            "time": "2020-09-21T20:44:02+00:00"
         },
         {
             "name": "facebook/xhp-lib",
@@ -435,16 +435,16 @@
         },
         {
             "name": "hhvm/hhast",
-            "version": "v4.72.2",
+            "version": "v4.72.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhast.git",
-                "reference": "1efa83d718b0ba057e9d394877233211cfd45b41"
+                "reference": "21360cba960c99a6ce5ecc35dcb4d069679900a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/1efa83d718b0ba057e9d394877233211cfd45b41",
-                "reference": "1efa83d718b0ba057e9d394877233211cfd45b41",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/21360cba960c99a6ce5ecc35dcb4d069679900a8",
+                "reference": "21360cba960c99a6ce5ecc35dcb4d069679900a8",
                 "shasum": ""
             },
             "require": {
@@ -481,20 +481,20 @@
                 "MIT"
             ],
             "description": "A mutable AST library for Hack with linting and code migrations",
-            "time": "2020-09-09T20:45:28+00:00"
+            "time": "2020-09-21T21:28:38+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhvm-autoload.git",
-                "reference": "0cae9edacf1f17dc0449e9a6bcc7cb38fa7a213a"
+                "reference": "37a994abc16eae898eb6692e1d2682496f01124c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/0cae9edacf1f17dc0449e9a6bcc7cb38fa7a213a",
-                "reference": "0cae9edacf1f17dc0449e9a6bcc7cb38fa7a213a",
+                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/37a994abc16eae898eb6692e1d2682496f01124c",
+                "reference": "37a994abc16eae898eb6692e1d2682496f01124c",
                 "shasum": ""
             },
             "require": {
@@ -528,7 +528,7 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2020-08-17T19:22:55+00:00"
+            "time": "2020-09-21T20:36:25+00:00"
         },
         {
             "name": "hhvm/hsl",
@@ -692,16 +692,16 @@
         },
         {
             "name": "usox/hackttp",
-            "version": "dev-master",
+            "version": "v0.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/usox/hackttp.git",
-                "reference": "a4bbea9d3f6207799900c5119d6a8360d79da77e"
+                "reference": "bbf8b5e06e4e07d4bdf198e8ad82f70f5da1178f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/usox/hackttp/zipball/a4bbea9d3f6207799900c5119d6a8360d79da77e",
-                "reference": "a4bbea9d3f6207799900c5119d6a8360d79da77e",
+                "url": "https://api.github.com/repos/usox/hackttp/zipball/bbf8b5e06e4e07d4bdf198e8ad82f70f5da1178f",
+                "reference": "bbf8b5e06e4e07d4bdf198e8ad82f70f5da1178f",
                 "shasum": ""
             },
             "require": {
@@ -747,22 +747,22 @@
                 "response",
                 "stream"
             ],
-            "time": "2020-08-18T04:09:25+00:00"
+            "time": "2020-07-13T10:20:44+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "facebook/fbexpect",
-            "version": "v2.7.6",
+            "version": "v2.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/fbexpect.git",
-                "reference": "12829749366e1b66d6cf74c29e3106ea0d674e8a"
+                "reference": "dcf1beb1b9e264396495aa120a3752fddfbeca95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/12829749366e1b66d6cf74c29e3106ea0d674e8a",
-                "reference": "12829749366e1b66d6cf74c29e3106ea0d674e8a",
+                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/dcf1beb1b9e264396495aa120a3752fddfbeca95",
+                "reference": "dcf1beb1b9e264396495aa120a3752fddfbeca95",
                 "shasum": ""
             },
             "require": {
@@ -781,7 +781,7 @@
                 "MIT"
             ],
             "description": "Unit test helpers for Facebook projects",
-            "time": "2020-08-17T19:07:38+00:00"
+            "time": "2020-09-11T00:43:51+00:00"
         },
         {
             "name": "hhvm/hacktest",
@@ -825,70 +825,11 @@
             ],
             "description": "The Hack Test Library",
             "time": "2020-07-01T22:27:25+00:00"
-        },
-        {
-            "name": "usox/hackmock",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/usox/hackmock.git",
-                "reference": "e34b812ab1e4b877945151d9c15739c1ce919b38"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/usox/hackmock/zipball/e34b812ab1e4b877945151d9c15739c1ce919b38",
-                "reference": "e34b812ab1e4b877945151d9c15739c1ce919b38",
-                "shasum": ""
-            },
-            "require": {
-                "facebook/fbexpect": "^2.3",
-                "facebook/hack-codegen": "^4",
-                "hhvm": "^4.1",
-                "hhvm/hacktest": "^1.4|^2.0",
-                "hhvm/hsl": "^4.1",
-                "hhvm/type-assert": "^3.2|^4.0"
-            },
-            "require-dev": {
-                "hhvm/hhast": "^4.1"
-            },
-            "suggest": {
-                "slack/hack-sql-fake": "Database Testing library for Hacklang"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Usox\\HackMock\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Jakob",
-                    "email": "dev@usox.org",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Mocking framework for hacklang",
-            "homepage": "https://github.com/usox/hackmock",
-            "keywords": [
-                "hack",
-                "hacklang",
-                "hhvm",
-                "mock",
-                "testing"
-            ],
-            "time": "2020-09-03T06:46:08+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "usox/hackttp": 20,
-        "usox/hackmock": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/hackttp.patch
+++ b/hackttp.patch
@@ -1,0 +1,37 @@
+diff --git a/vendor/usox/hackttp/src/Marshaler/UploadedFileMarshaler.hack b/vendor/usox/hackttp/src/Marshaler/UploadedFileMarshaler.hack
+index 8d65d5c..0180888 100644
+--- a/vendor/usox/hackttp/src/Marshaler/UploadedFileMarshaler.hack
++++ b/vendor/usox/hackttp/src/Marshaler/UploadedFileMarshaler.hack
+@@ -42,24 +42,24 @@ final class UploadedFileMarshaler implements UploadedFileMarshalerInterface {
+ 	public function marshal(dict<string, mixed> $files): dict<string, Message\UploadedFileInterface> {
+ 		$result = dict[];
+ 		foreach ($files as $index_name => $file_entry) {
+-			if (!\is_array($file_entry)) {
++			if (!$file_entry is KeyedContainer<_, _>) {
+ 				continue;
+ 			}
+
+ 			if ($file_entry is UploadedFileType) {
+ 				$result[$index_name] = $this->createUploadedFile($file_entry);
+ 			} else {
+-				$file_count = C\count($file_entry['tmp_name']);
++				$file_count = C\count($file_entry['tmp_name'] as Container<_>);
+ 				for ($i = 0; $i < $file_count; $i++) {
+ 					$key = Str\format('%s[%d]', $index_name, $i);
+ 					$result[$key] = $this->createUploadedFile(
+ 						shape(
+-							'tmp_name' => $file_entry['tmp_name'][$i],
+-							'size' => $file_entry['size'][$i],
+-							'error' => $file_entry['error'][$i],
+-							'type' => $file_entry['type'][$i] ?? null,
+-							'name' => $file_entry['name'][$i] ?? null
+-						)
++							'tmp_name' => $file_entry['tmp_name'] as KeyedContainer<_, _>[$i],
++							'size' => $file_entry['size'] as KeyedContainer<_, _>[$i],
++							'error' => $file_entry['error'] as KeyedContainer<_, _>[$i],
++							'type' => $file_entry['type'] as KeyedContainer<_, _>[$i] ?? null,
++							'name' => $file_entry['name'] as KeyedContainer<_, _>[$i] ?? null,
++						) as UploadedFileType,
+ 					);
+ 				}
+ 			}


### PR DESCRIPTION
Updating the docs site to the latest HHVM version often gets temporarily blocked because the [hackttp](https://github.com/usox/hackttp) dependency causes Hack errors with the respective HHVM version (see https://github.com/usox/hackttp/commits/master -- pretty much every recent commit is due to that). The owner has been pretty responsive about merging our PRs and tagging releases, but it does occasionally take a while so it would be good if we didn't have to rely on it.

This adds the option to automatically patch the hackttp package after composer install/update, with an arbitrary patch (the included patch is from the latest hackttp commit, which didn't make it into a tagged release yet). We can revert this when a new hackttp release is tagged, then re-introduce it whenever we need it again.