### PR TITLE
Update FB-only header for greater clarity

### DIFF
--- a/guides/hack/01-getting-started/01-getting-started.md
+++ b/guides/hack/01-getting-started/01-getting-started.md
@@ -1,7 +1,7 @@
 ```yamlmeta
 {
   "fbonly messages": [
-    "Unless you are specifically working on open source Hack code, you want [Facebook's internal documentation](https://our.internmc.facebook.com/intern/wiki/First-app/) instead."
+    "Unless you are specifically working on open source Hack code, you want [Facebook's internal documentation](https://our.internmc.facebook.com/intern/wiki/First-app/) instead for dev environment setup.  If you're just looking to [learn the Hack language itself](https://docs.hhvm.com/hack/source-code-fundamentals/introduction), skip this Getting Started section."
   ]
 }
 ```


### PR DESCRIPTION
Make it clear that the open source docs *are* the right place to learn the language itself, just not the place for dev environment setup within FB, per conversation with Fred Emmot.