### PR TITLE
Fix formatting error in escape sequence table

### DIFF
--- a/guides/hack/02-source-code-fundamentals/19-literals.md
+++ b/guides/hack/02-source-code-fundamentals/19-literals.md
@@ -73,8 +73,8 @@ Here are the supported escape sequences:
 
 Escape sequence | Character name | Unicode character
 --------------- | --------------| ------
-\$  | Dollar sign | U+0024
-\"  | Double quote | U+0022
+\\\$  | Dollar sign | U+0024
+\\\"  | Double quote | U+0022
 \\\\  | Backslash | U+005C
 \e  | Escape | U+001B
 \f  | Form feed | U+000C


### PR DESCRIPTION
Previously the dollar sign and double quote were rendered without a preceding backslash.