### PR TITLE
use Hack output instead of HHVM in .type-errors examples

### DIFF
--- a/guides/hack/06-classes/28-trait-and-interface-requirements-examples/interface-bad.php.type-errors.example.typechecker.out
+++ b/guides/hack/06-classes/28-trait-and-interface-requirements-examples/interface-bad.php.type-errors.example.typechecker.out
@@ -1,0 +1,28 @@
+File "/home/example/interface-bad.php", line 24, characters 24-29:
+Failure to satisfy requirement: HHVM\UserDocumentation\Guides\Hack\Classes\TraitAndInterfaceRequirements\InterfaceBad\Machine (Typing[4111])
+  File "/home/example/interface-bad.php", line 17, characters 19-25:
+  Required here
+
+File "/home/example/interface-bad.php", line 24, characters 7-11:
+This type doesn't implement the method `closeDoors` (Typing[4054])
+  File "/home/example/interface-bad.php", line 24, characters 24-29:
+  Which is required by this interface
+  File "/home/example/interface-bad.php", line 12, characters 19-28:
+  As defined here
+
+File "/home/example/interface-bad.php", line 24, characters 7-11:
+This type doesn't implement the method `openDoors` (Typing[4054])
+  File "/home/example/interface-bad.php", line 24, characters 24-29:
+  Which is required by this interface
+  File "/home/example/interface-bad.php", line 9, characters 19-27:
+  As defined here
+
+File "/home/example/interface-bad.php", line 36, characters 17-23:
+No method `takeOff` in `HHVM\UserDocumentation\Guides\Hack\Classes\TraitAndInterfaceRequirements\InterfaceBad\Paper` (Typing[4053])
+  File "/home/example/interface-bad.php", line 25, characters 19-21:
+  Did you mean `fly` instead?
+  File "/home/example/interface-bad.php", line 34, characters 12-16:
+  This is why I think it is an object of type HHVM\UserDocumentation\Guides\Hack\Classes\TraitAndInterfaceRequirements\InterfaceBad\Paper
+  File "/home/example/interface-bad.php", line 24, characters 7-11:
+  Declaration of `HHVM\UserDocumentation\Guides\Hack\Classes\TraitAndInterfaceRequirements\InterfaceBad\Paper` is here
+

--- a/guides/hack/06-classes/28-trait-and-interface-requirements-examples/trait-bad.php.type-errors.example.typechecker.out
+++ b/guides/hack/06-classes/28-trait-and-interface-requirements-examples/trait-bad.php.type-errors.example.typechecker.out
@@ -1,0 +1,5 @@
+File "/home/example/trait-bad.php", line 34, characters 7-11:
+Failure to satisfy requirement: HHVM\UserDocumentation\Guides\Hack\Classes\TraitAndInterfaceRequirements\TraitBad\Machine (Typing[4111])
+  File "/home/example/trait-bad.php", line 21, characters 19-25:
+  Required here
+

--- a/guides/hack/11-built-in-types/71-dynamic-examples/coercion_from_dynamic.php.type-errors.example.typechecker.out
+++ b/guides/hack/11-built-in-types/71-dynamic-examples/coercion_from_dynamic.php.type-errors.example.typechecker.out
@@ -1,0 +1,7 @@
+File "/home/example/coercion_from_dynamic.php", line 14, characters 15-16:
+Invalid argument (Typing[4110])
+  File "/home/example/coercion_from_dynamic.php", line 9, characters 22-38:
+  Expected `shape('a' => int)`
+  File "/home/example/coercion_from_dynamic.php", line 11, characters 17-23:
+  But got `dynamic`
+

--- a/guides/hack/11-built-in-types/71-dynamic-examples/coercion_from_union.php.type-errors.example.typechecker.out
+++ b/guides/hack/11-built-in-types/71-dynamic-examples/coercion_from_union.php.type-errors.example.typechecker.out
@@ -1,0 +1,7 @@
+File "/home/example/coercion_from_union.php", line 21, characters 17-18:
+Invalid argument (Typing[4110])
+  File "/home/example/coercion_from_union.php", line 9, characters 24-29:
+  Expected `string`
+  File "/home/example/coercion_from_union.php", line 11, characters 38-40:
+  But got `int`
+

--- a/guides/hack/11-built-in-types/71-dynamic.md
+++ b/guides/hack/11-built-in-types/71-dynamic.md
@@ -31,8 +31,8 @@ dynamic, results in another dynamic.
 # Coercion
 
 The `dynamic` type sits outside the normal type hierarchy. It is a supertype only of the bottom type `nothing`
-and a subtype only of the top type `mixed`. The type interfaces with other types via coercion (`~>` in the 
-examples). All types coerce to `dynamic`, which allows callers to pass any type into a function that expects dynamic. Also, any type 
+and a subtype only of the top type `mixed`. The type interfaces with other types via coercion (`~>` in the
+examples). All types coerce to `dynamic`, which allows callers to pass any type into a function that expects dynamic. Also, any type
 coerces to its supertypes. Coercion points include function calls, return statements, and property assignment.
 
 ```coercion_to_dynamic.php no-auto-output
@@ -54,7 +54,7 @@ The runtime enforces a set of types by throwing `TypeHintViolationException` whe
 
 Hack approximates this runtime behavior by allowing values of type `dynamic` to coerce to enforceable types at coercion points.
 
-```coercion_from_dynamic.php.type-errors no-auto-output
+```coercion_from_dynamic.php.type-errors
 function enforced(int $i): void {}
 function notEnforced(shape('a' => int) $s): void {}
 

--- a/guides/hack/12-generics/20-reified-generics-examples/new-reify.php.type-errors.example.typechecker.out
+++ b/guides/hack/12-generics/20-reified-generics-examples/new-reify.php.type-errors.example.typechecker.out
@@ -1,0 +1,5 @@
+File "/home/example/new-reify.php", line 20, characters 5-5:
+A newable type argument must be a concrete class or a newable type parameter. (Typing[4307])
+  File "/home/example/new-reify.php", line 14, characters 32-32:
+  Type parameter `T` was declared `__Newable` here
+

--- a/guides/hack/12-generics/20-reified-generics-examples/type-verification-2.php.type-errors.example.typechecker.out
+++ b/guides/hack/12-generics/20-reified-generics-examples/type-verification-2.php.type-errors.example.typechecker.out
@@ -1,0 +1,18 @@
+File "/home/example/type-verification-2.php", line 11, characters 10-21:
+Invalid return type (Typing[4110])
+  File "/home/example/type-verification-2.php", line 10, characters 30-30:
+  Expected `T`
+  File "/home/example/type-verification-2.php", line 10, characters 30-30:
+  This type argument to `HHVM\UserDocumentation\Guides\Hack\Generics\ReifiedGenerics\TypeVerification2\C` must match exactly (it is invariant)
+  File "/home/example/type-verification-2.php", line 11, characters 16-18:
+  But got `int`
+
+File "/home/example/type-verification-2.php", line 17, characters 10-14:
+Invalid argument (Typing[4110])
+  File "/home/example/type-verification-2.php", line 17, characters 5-7:
+  Expected `int`
+  File "/home/example/type-verification-2.php", line 10, characters 21-21:
+    via this generic `T`
+  File "/home/example/type-verification-2.php", line 17, characters 10-14:
+  But got `string`
+

--- a/guides/hack/12-generics/20-reified-generics-examples/type-verification.php.type-errors.example.typechecker.out
+++ b/guides/hack/12-generics/20-reified-generics-examples/type-verification.php.type-errors.example.typechecker.out
@@ -1,0 +1,9 @@
+File "/home/example/type-verification.php", line 17, characters 5-7:
+Invalid argument (Typing[4110])
+  File "/home/example/type-verification.php", line 10, characters 14-16:
+  Expected `int`
+  File "/home/example/type-verification.php", line 10, characters 14-16:
+  This type argument to `HHVM\UserDocumentation\Guides\Hack\Generics\ReifiedGenerics\TypeVerification\C` must match exactly (it is invariant)
+  File "/home/example/type-verification.php", line 16, characters 15-20:
+  But got `string`
+

--- a/guides/hack/12-generics/20-reified-generics.md
+++ b/guides/hack/12-generics/20-reified-generics.md
@@ -13,7 +13,7 @@ The goal of opt-in reified generics is to bridge the gap between generics and ru
 
 ## Parameter and return type verification
 
-```type-verification.php.type-errors no-auto-output
+```type-verification.php.type-errors
 class C<reify T> {}
 
 function f(C<int> $c): void {}
@@ -31,7 +31,7 @@ enable_experimental_tc_features=reified_generics
 
 The reified type parameter is checked as well:
 
-```type-verification-2.php.type-errors no-auto-output
+```type-verification-2.php.type-errors
 class C<reify T> {}
 
 function f<reify T>(T $x): C<T> {
@@ -92,7 +92,7 @@ C<int, string> // NOT enforceable as C's second generic is erased
 
 Prior to reified generics, in order to create a new instance of a class without a constant class name, you'd need to pass it as `classname<T>` which is not type safe. In the runtime, classnames are strings.
 
-```new-reify.php.type-errors no-auto-output
+```new-reify.php.type-errors
 <<__ConsistentConstruct>>
 abstract class A {}
 

--- a/guides/hack/20-attributes/07-predefined-attributes-examples/enforceable.php.type-errors.example.typechecker.out
+++ b/guides/hack/20-attributes/07-predefined-attributes-examples/enforceable.php.type-errors.example.typechecker.out
@@ -1,0 +1,12 @@
+File "/home/example/enforceable.php", line 16, characters 11-22:
+Invalid `as` expression hint (Typing[4195])
+  File "/home/example/enforceable.php", line 9, characters 23-28:
+  The `as` operator cannot be used with the abstract type constant Tnoenf because it is not marked `<<__Enforceable>>`
+
+File "/home/example/enforceable.php", line 22, characters 14-17:
+Invalid type (Typing[4302])
+  File "/home/example/enforceable.php", line 10, characters 5-17:
+  Type constant `Tenf` was declared `__Enforceable` here
+  File "/home/example/enforceable.php", line 22, characters 21-39:
+  This type is not enforceable because it has a function type
+

--- a/guides/hack/20-attributes/07-predefined-attributes.md
+++ b/guides/hack/20-attributes/07-predefined-attributes.md
@@ -88,7 +88,7 @@ dynamic instantiations of classes without this attribute.
 
 A type is _enforceable_ if it can be used in `is` and `as` expressions.  Examples of non-enforceable types are function types and erased (non-reified) generics.  The `__Enforceable` attribute is used to annotate abstract type constants so they can only be instantiated with enforceable types, and thus used in `is` and `as` expressions. The attribute restricts deriving type constants to values that are valid for a type test.
 
-```enforceable.php.type-errors no-auto-output
+```enforceable.php.type-errors
 abstract class A {
   abstract const type Tnoenf;
   <<__Enforceable>>

--- a/guides/hack/21-XHP/01-introduction-examples/tag-matching-validation.php.type-errors.example.typechecker.out
+++ b/guides/hack/21-XHP/01-introduction-examples/tag-matching-validation.php.type-errors.example.typechecker.out
@@ -1,0 +1,3 @@
+File "/home/example/tag-matching-validation.php", line 20, characters 43-70:
+XHP: mismatched tag: `naps` not the same as `span` (Parsing[1002])
+

--- a/src/markdown-extensions/extracted-code-blocks/FilterBase.php
+++ b/src/markdown-extensions/extracted-code-blocks/FilterBase.php
@@ -185,6 +185,7 @@ abstract class FilterBase extends Markdown\RenderFilter {
 
     // Generate/verify typechecker output, if type errors are expected.
     if ($expected_type_errors) {
+      $show_output = !C\contains_key($flags, Flags::NO_AUTO_OUTPUT);
       if (
         !self::hasValidOutputFileSet(
           $hack_file_path,
@@ -192,24 +193,26 @@ abstract class FilterBase extends Markdown\RenderFilter {
           Files::EXAMPLE_TYPECHECKER_OUT,
           Files::TYPECHECKER_EXPECTF,
           Files::TYPECHECKER_EXPECTREGEX,
-          false, // needs example (TODO: see below)
+          // don't generate .example.out if output is not shown in the guide
+          $show_output,
         )
       ) {
-        static::processMissingTypecheckerOutput($hack_file_path, false /*TODO*/);
+        static::processMissingTypecheckerOutput($hack_file_path, $show_output);
       }
-      /* TODO: Test if this is preferable to the HHVM output.
-      $output_title = 'Typechecker output';
-      $output = \file_exists($hack_file_path.'.'.Files::TYPECHECKER_EXPECT)
-        ? \file_get_contents($hack_file_path.'.'.Files::TYPECHECKER_EXPECT)
-        : \file_get_contents(
-            $hack_file_path.'.'.Files::EXAMPLE_TYPECHECKER_OUT,
-          );
-      */
+      if ($show_output) {
+        $output_title = 'Typechecker output';
+        $output = \file_exists($hack_file_path.'.'.Files::TYPECHECKER_EXPECT)
+          ? \file_get_contents($hack_file_path.'.'.Files::TYPECHECKER_EXPECT)
+          : \file_get_contents(
+              $hack_file_path.'.'.Files::EXAMPLE_TYPECHECKER_OUT,
+            );
+      }
     }
 
     // Generate/verify HHVM output.
     if (!C\contains_key($flags, Flags::NO_EXEC)) {
-      $show_output = !C\contains_key($flags, Flags::NO_AUTO_OUTPUT);
+      $show_output = !$expected_type_errors &&
+        !C\contains_key($flags, Flags::NO_AUTO_OUTPUT);
       if (
         !self::hasValidOutputFileSet(
           $hack_file_path,


### PR DESCRIPTION
For examples that demonstrate type errors, the Hack output is probably more relevant than HHVM (runtime) output.

This is the diff after build: https://gist.github.com/jjergus/7a7d571d8a7519836f0099a103edd077

I also removed `no-auto-output` from some examples that previously didn't have useful output to show, but now do.