### PR TITLE
Remove Warning header from Contexts and Capabilities sections

### DIFF
--- a/guides/hack/13-contexts-and-capabilities/01-introduction.md
+++ b/guides/hack/13-contexts-and-capabilities/01-introduction.md
@@ -1,9 +1,3 @@
-## WARNING WARNING WARNING
-
-This section is under active development and represents an unreleased feature
-
-## Back to your regularly scheduled docs
-
 Contexts and capabilities provide a way to specify a set of capabilities for a function's implementation and a permission system for its' callers. These capabilities may be in terms of what functions may be used in the implementation (e.g. a pure function cannot call non-pure functions), or in terms of other language features (e.g. a pure function can not write properties on `$this`).
 
 Capabilities are permissions or descriptions of a permission. For example, one might consider the ability to do IO or access globals as capabilities. Contexts are a higher level representation of a set of capabilities. A function may be comprised of one or more contexts which represent the set union of the underlying capabilities.

--- a/guides/hack/13-contexts-and-capabilities/02-local-operations.md
+++ b/guides/hack/13-contexts-and-capabilities/02-local-operations.md
@@ -1,16 +1,10 @@
-## WARNING WARNING WARNING
-
-This section is under active development and represents an unreleased feature
-
-## Back to your regularly scheduled docs
-
 The existence of a capability (or lack thereof) within the contexts of a function plays a direct role in the operations allowed within that function.
 
 Consider the following potential (although not necessarily planned) contexts (with implied matching capabilities):
 * `throws<T>`, representing the permission to throw an exception type `Te <: T`
 * `io`, representing the permission to do io
 * `statics`, representing the permission to access static members and global variables
-* `writeProp`, representing the permission to mutate properties of objects
+* `write_prop`, representing the permission to mutate properties of objects
 * `dynamic`, representing the permission to cast a value to the `dynamic` type
 
 In all of the below cases, the relevant local operations are only legal due to the existence of the matching capabilities within the context of the function. In the world where all these contexts (and matching capabilities exist), some or all may be included within the `defaults` context.
@@ -58,7 +52,7 @@ class SomeClass {
   public int $i = 0;
 }
 
-function reads_and_writes_prop(SomeClass $sc)[writeprop]: void {
+function reads_and_writes_prop(SomeClass $sc)[write_prop]: void {
   $sc->i++;
 }
 ```

--- a/guides/hack/13-contexts-and-capabilities/03-closures.md
+++ b/guides/hack/13-contexts-and-capabilities/03-closures.md
@@ -1,9 +1,3 @@
-## WARNING WARNING WARNING
-
-This section is under active development and represents an unreleased feature
-
-## Back to your regularly scheduled docs
-
 As with standard functions, closures may optionally choose to list one or more contexts. Note that the outer function may or may not have its own context list. Lambdas wishing to specify a list of contexts must include a (possibly empty) parenthesized argument list.
 
 ```hack

--- a/guides/hack/13-contexts-and-capabilities/04-higher-order-functions.md
+++ b/guides/hack/13-contexts-and-capabilities/04-higher-order-functions.md
@@ -1,9 +1,3 @@
-## WARNING WARNING WARNING
-
-This section is under active development and represents an unreleased feature
-
-## Back to your regularly scheduled docs
-
 One may define a higher order function whose context depends on the dynamic context of one or more passed in function arguments.
 
 ```hack

--- a/guides/hack/13-contexts-and-capabilities/05-contexts-and-subtyping.md
+++ b/guides/hack/13-contexts-and-capabilities/05-contexts-and-subtyping.md
@@ -1,9 +1,3 @@
-## WARNING WARNING WARNING
-
-This section is under active development and represents an unreleased feature
-
-## Back to your regularly scheduled docs
-
 Capabilities are contravariant.
 
 This implies that a closure that requires a set of capabilities S<sub>a</sub> may be passed where the expected type is a function that requires S<sub>b</sub> as long as S<sub>a</sub> ⊆ S<sub>b</sub>.

--- a/guides/hack/13-contexts-and-capabilities/06-context-constants.md
+++ b/guides/hack/13-contexts-and-capabilities/06-context-constants.md
@@ -1,9 +1,3 @@
-## WARNING WARNING WARNING
-
-This section is under active development and represents an unreleased feature
-
-## Back to your regularly scheduled docs
-
 Classes and interfaces may define context constants:
 
 ```hack

--- a/guides/hack/13-contexts-and-capabilities/06-context-constants.md
+++ b/guides/hack/13-contexts-and-capabilities/06-context-constants.md
@@ -1,3 +1,5 @@
+# NOTE: Context constant *constraints* are not yet available
+
 Classes and interfaces may define context constants:
 
 ```hack

--- a/guides/hack/13-contexts-and-capabilities/07-dependent-contexts-continued.md
+++ b/guides/hack/13-contexts-and-capabilities/07-dependent-contexts-continued.md
@@ -1,9 +1,3 @@
-## WARNING WARNING WARNING
-
-This section is under active development and represents an unreleased feature
-
-## Back to your regularly scheduled docs
-
 Dependent contexts may be accessed off of nullable parameters. If the dynamic value of the parameter is null, then the capability set required by that parameter is empty.
 
 ```hack

--- a/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities.md
+++ b/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities.md
@@ -1,9 +1,3 @@
-## WARNING WARNING WARNING
-
-This section is under active development and represents an unreleased feature
-
-## Back to your regularly scheduled docs
-
 The following contexts and capabilities are implemented at present.
 
 ## Capabilities


### PR DESCRIPTION
In addition, minor grammatical edits and a new warning header about lack of context constant constraints at launch time.