### PR TITLE
Build and test on GitHub actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,7 @@ jobs:
         hhvm: [ '4.88' ]
     runs-on: ${{matrix.os}}-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Fetch docker images
         run: |
           docker pull hhvm/hhvm:${{matrix.hhvm}}-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,29 @@
+name: Continuous Integration
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '42 15 * * *'
+jobs:
+  build:
+    name: Build and Test
+    strategy:
+      matrix:
+        os: [ ubuntu ]
+        hhvm: [ '4.88' ]
+    runs-on: ${{matrix.os}}-latest
+    steps:
+      - name: Fetch docker images
+        run: |
+          docker pull hhvm/hhvm:${{matrix.hhvm}}-latest
+          docker pull hhvm/hhvm-proxygen:${{matrix.hhvm}}-latest
+      - name: Build
+        run: docker build -t hhvm/user-documentation:scratch -f .deploy/built-site.Dockerfile .
+      - name: Typecheck
+        run: docker run --rm -w /var/www hhvm/user-documentation:scratch hh_server --check .
+      - name: Run tests
+        run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hacktest tests/
+      - name: Lint
+        run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hhast-lint
+      - name: Verify codegen is unchanged
+        run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hh-codegen-verify-signatures src


### PR DESCRIPTION
I've not yet added the deploy step; for now, this runs along side the TravisCI testing.

Still using Docker as we're going to want to keep building and publishing docker images - both to dockerhub, and to the live AWS site