### PR TITLE
Deploy from GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,3 +28,46 @@ jobs:
         run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hhast-lint
       - name: Verify codegen is unchanged
         run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hh-codegen-verify-signatures src
+      - name: Export Docker image
+        run: docker save hhvm/user-documentation:scratch -o hack-docs.tar
+      - name: Save Docker image as build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-image
+          path: hack-docs.tar
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Docker image from build step
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-image
+      - name: Import Docker image
+        run: docker load --input hack-docs.tar
+      - name: Build HHBC repo
+        run: |
+          mkdir ${{runner.temp}}/repo-out
+          docker run --rm \
+            -v ${{runner.temp}}/repo-out:/var/out \
+            -w /var/www \
+            hhvm/user-documentation:scratch \
+            .deploy/build-repo.sh
+      - name: Set image tag/name variables
+        run: |
+          DEPLOY_REV=$(git rev-parse --short HEAD)
+          HHVM_VERSION=$(awk '/APIProduct::HACK/{print $NF}' src/codegen/PRODUCT_TAGS.php | cut -f2 -d- | cut -f1-2 -d.)
+          IMAGE_TAG="HHVM-${HHVM_VERSION}-$(date +%Y-%m-%d)-${DEPLOY_REV}"
+          IMAGE_NAME="hhvm/user-documentation:$IMAGE_TAG"
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+      - name: Build repo-authoritative Docker image
+        run: |
+          cp hhvm.prod.ini ${{runner.temp}}/repo-out
+          cp .deploy/prod.Dockerfile ${{runner.temp}}/repo-out/Dockerfile
+          (
+            cd ${{runner.temp}}/repo-out
+            docker build -t ${IMAGE_NAME} .
+          )

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,6 +36,7 @@ jobs:
           name: docker-image
           path: hack-docs.tar
   deploy:
+    # if: (github.event_name == "push" && github.ref == "refs/heads/master")
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
@@ -71,3 +72,20 @@ jobs:
             cd ${{runner.temp}}/repo-out
             docker build -t ${IMAGE_NAME} .
           )
+      - name: Install ElasticBeanstalk CLI
+        run: |
+          git clone --depth 10 https://github.com/aws/aws-elastic-beanstalk-cli-setup.git
+          ./aws-elastic-beanstalk-cli-setup/scripts/bundled_installer
+      - name: Configure ElasticBeanstalk
+        run: |
+          # Select an application to use: 1) hhvm-hack-docs
+          # Select the default environment: 1) ... doesn't matter, managed by script
+          # Do you want to continue with CodeCommit? n
+          echo -e "1\n1\nn\n" | eb init -r us-west-2
+          eb status
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      - name: Logging in to DockerHub
+          echo "${{secrets.DOCKERHUB_PASSWORD}}" | docker login -u "${{secrets.DOCKERHUB_USER}}" \
+            --password-stdin

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           git clone --depth 10 https://github.com/aws/aws-elastic-beanstalk-cli-setup.git
           ./aws-elastic-beanstalk-cli-setup/scripts/bundled_installer
+          echo "PATH=$HOME/.ebcli-virtual-env/executables:$PATH" >> $GITHUB_ENV
       - name: Configure ElasticBeanstalk
         run: |
           # Select an application to use: 1) hhvm-hack-docs

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,5 +87,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
       - name: Logging in to DockerHub
+        run: |
           echo "${{secrets.DOCKERHUB_PASSWORD}}" | docker login -u "${{secrets.DOCKERHUB_USER}}" \
             --password-stdin


### PR DESCRIPTION
Straight port of TravisCI stuff.

We should probably do less in Docker, however it's nice that we can quickly switch between 'full' and 'prod' (no dev dependencies etc) with stuff in docker.

Starting with a straight port to unblock moving, then we should:
- avoid docker where not needed
- if we still keep some basic testing in docker, add testing for standard non-docker developer flow too