### PR TITLE
update coeffects availability notes

### DIFF
--- a/guides/hack/13-contexts-and-capabilities/01-introduction.md
+++ b/guides/hack/13-contexts-and-capabilities/01-introduction.md
@@ -1,4 +1,5 @@
-# This is a new feature which must be enabled in your projects' configuration
+**Note:** Context and capabilities are enabled by default since
+[HHVM 4.93](https://hhvm.com/blog/2021/01/19/hhvm-4.93.html).
 
 Contexts and capabilities provide a way to specify a set of capabilities for a function's implementation and a permission system for its' callers. These capabilities may be in terms of what functions may be used in the implementation (e.g. a pure function cannot call non-pure functions), or in terms of other language features (e.g. a pure function can not write properties on `$this`).
 

--- a/guides/hack/13-contexts-and-capabilities/02-local-operations.md
+++ b/guides/hack/13-contexts-and-capabilities/02-local-operations.md
@@ -1,4 +1,5 @@
-# This is a new feature which must be enabled in your projects' configuration
+**Note:** Context and capabilities are enabled by default since
+[HHVM 4.93](https://hhvm.com/blog/2021/01/19/hhvm-4.93.html).
 
 The existence of a capability (or lack thereof) within the contexts of a function plays a direct role in the operations allowed within that function.
 
@@ -25,7 +26,7 @@ class BarException extends Exception {}
 
 function throws_foo_exception()[throws<FooException>]: void {
   throw new FooException(); // ok: FooException <: FooException
-  throw new FooChildException(); // ok: FooChildException <: FooException  
+  throw new FooChildException(); // ok: FooChildException <: FooException
 }
 
 function throws_bar_exception()[throws<BarException>]: void {

--- a/guides/hack/13-contexts-and-capabilities/03-closures.md
+++ b/guides/hack/13-contexts-and-capabilities/03-closures.md
@@ -1,4 +1,5 @@
-# This is a new feature which must be enabled in your projects' configuration
+**Note:** Context and capabilities are enabled by default since
+[HHVM 4.93](https://hhvm.com/blog/2021/01/19/hhvm-4.93.html).
 
 As with standard functions, closures may optionally choose to list one or more contexts. Note that the outer function may or may not have its own context list. Lambdas wishing to specify a list of contexts must include a (possibly empty) parenthesized argument list.
 

--- a/guides/hack/13-contexts-and-capabilities/04-higher-order-functions.md
+++ b/guides/hack/13-contexts-and-capabilities/04-higher-order-functions.md
@@ -1,4 +1,5 @@
-# This is a new feature which must be enabled in your projects' configuration
+**Note:** Context and capabilities are enabled by default since
+[HHVM 4.93](https://hhvm.com/blog/2021/01/19/hhvm-4.93.html).
 
 One may define a higher order function whose context depends on the dynamic context of one or more passed in function arguments.
 

--- a/guides/hack/13-contexts-and-capabilities/05-contexts-and-subtyping.md
+++ b/guides/hack/13-contexts-and-capabilities/05-contexts-and-subtyping.md
@@ -1,4 +1,5 @@
-# This is a new feature which must be enabled in your projects' configuration
+**Note:** Context and capabilities are enabled by default since
+[HHVM 4.93](https://hhvm.com/blog/2021/01/19/hhvm-4.93.html).
 
 Capabilities are contravariant.
 
@@ -13,9 +14,9 @@ function requires_rand_io_arg((function()[rand, io]: void) $f): void {
 
 function caller(): void {
   // passing a function that requires fewer capabilities
-  requires_rand_io_arg(()[rand] ==> {/* some fn body */}); 
-  // passing a function that requires no capabilities 
-  requires_rand_io_arg(()[] ==> {/* some fn body */});  
+  requires_rand_io_arg(()[rand] ==> {/* some fn body */});
+  // passing a function that requires no capabilities
+  requires_rand_io_arg(()[] ==> {/* some fn body */});
 }
 ```
 

--- a/guides/hack/13-contexts-and-capabilities/06-context-constants.md
+++ b/guides/hack/13-contexts-and-capabilities/06-context-constants.md
@@ -1,6 +1,7 @@
-# This is a new feature which must be enabled in your projects' configuration
+**Note:** Context and capabilities are enabled by default since
+[HHVM 4.93](https://hhvm.com/blog/2021/01/19/hhvm-4.93.html).
 
-# NOTE: Context constant *constraints* are not yet available
+**Note:** Context constant *constraints* are not yet available.
 
 Classes and interfaces may define context constants:
 
@@ -25,12 +26,12 @@ may have one or more bounds,
 
 ```hack
 abstract class WithConstant {
-  // Subclasses must require *at least* [io]  
-  abstract const ctx CAnotherOne as [io];   
+  // Subclasses must require *at least* [io]
+  abstract const ctx CAnotherOne as [io];
   // Subclasses must require *at most* [defaults]
-  abstract const ctx COne super [defaults]; 
-  // Subclasses must require *at most* [defaults] and *at least* [io, rand] 
-  abstract const ctx CMany super [defaults] as [io, rand]; 
+  abstract const ctx COne super [defaults];
+  // Subclasses must require *at most* [defaults] and *at least* [io, rand]
+  abstract const ctx CMany super [defaults] as [io, rand];
 }
 ```
 
@@ -39,7 +40,7 @@ and may have defaults, though only when abstract
 ```hack
 interface IWithConstant {
   abstract const ctx C = [defaults];
-  abstract const ctx CWithBound super [defaults] = [io];  
+  abstract const ctx CWithBound super [defaults] = [io];
 }
 ```
 

--- a/guides/hack/13-contexts-and-capabilities/07-dependent-contexts-continued.md
+++ b/guides/hack/13-contexts-and-capabilities/07-dependent-contexts-continued.md
@@ -1,4 +1,5 @@
-# This is a new feature which must be enabled in your projects' configuration
+**Note:** Context and capabilities are enabled by default since
+[HHVM 4.93](https://hhvm.com/blog/2021/01/19/hhvm-4.93.html).
 
 Dependent contexts may be accessed off of nullable parameters. If the dynamic value of the parameter is null, then the capability set required by that parameter is empty.
 
@@ -24,7 +25,7 @@ Parameters used for accessing a dependent context may not be reassigned.
 function nope(SomeClassWithConstant $t, (function()[_]: void) $f)[$t::C, ctx $f]: void {
   // both disallowed
   $t = get_some_other_value();
-  $f = get_some_other_value();  
+  $f = get_some_other_value();
 }
 ```
 

--- a/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities.md
+++ b/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities.md
@@ -1,4 +1,5 @@
-# This is a new feature which must be enabled in your projects' configuration
+**Note:** Context and capabilities are enabled by default since
+[HHVM 4.93](https://hhvm.com/blog/2021/01/19/hhvm-4.93.html).
 
 The following contexts and capabilities are implemented at present.
 
@@ -64,7 +65,7 @@ Class SomeClass {
 }
 
 function access_statics(SomeClass $sc): void {
-  SomeClass::$s; // or like this  
+  SomeClass::$s; // or like this
 }
 ```
 


### PR DESCRIPTION
The notes at the top of each file are the only change here, the rest is just removing some trailing whitespace.