### PR TITLE
Skip mcrouter examples for \HH\Asio\ functions if McRouter extension not present

### DIFF
--- a/api-examples/function.HH.Asio.mw.md
+++ b/api-examples/function.HH.Asio.mw.md
@@ -26,4 +26,6 @@ async function basic_usage_main(): Awaitable<void> {
     }
   }
 }
+```.skipif
+\Hack\UserDocumentation\API\Examples\MCRouter\skipif();
 ```

--- a/api-examples/function.HH.Asio.vw.md
+++ b/api-examples/function.HH.Asio.vw.md
@@ -26,4 +26,6 @@ async function basic_usage_main(): Awaitable<void> {
     }
   }
 }
+```.skipif
+\Hack\UserDocumentation\API\Examples\MCRouter\skipif();
 ```

--- a/build/extracted-examples/api/hack/function.HH.Asio.mw/basic-usage.hack.skipif
+++ b/build/extracted-examples/api/hack/function.HH.Asio.mw/basic-usage.hack.skipif
@@ -1,0 +1,11 @@
+// WARNING: Contains some auto-generated boilerplate code, see:
+// HHVM\UserDocumentation\MarkdownExt\ExtractedCodeBlocks\FilterBase::addBoilerplate
+
+namespace HHVM\UserDocumentation\Api\Hack\FunctionHHAsioMw\BasicUsage;
+
+<<__EntryPoint>>
+async function _main(): Awaitable<void> {
+  \init_docs_autoloader();
+
+  \Hack\UserDocumentation\API\Examples\MCRouter\skipif();
+}

--- a/build/extracted-examples/api/hack/function.HH.Asio.vw/basic-usage.hack.skipif
+++ b/build/extracted-examples/api/hack/function.HH.Asio.vw/basic-usage.hack.skipif
@@ -1,0 +1,11 @@
+// WARNING: Contains some auto-generated boilerplate code, see:
+// HHVM\UserDocumentation\MarkdownExt\ExtractedCodeBlocks\FilterBase::addBoilerplate
+
+namespace HHVM\UserDocumentation\Api\Hack\FunctionHHAsioVw\BasicUsage;
+
+<<__EntryPoint>>
+async function _main(): Awaitable<void> {
+  \init_docs_autoloader();
+
+  \Hack\UserDocumentation\API\Examples\MCRouter\skipif();
+}

--- a/src/markdown-extensions/extracted-code-blocks/ExtractFilter.php
+++ b/src/markdown-extensions/extracted-code-blocks/ExtractFilter.php
@@ -34,6 +34,12 @@ final class ExtractFilter extends FilterBase {
       \mkdir(\dirname($path), 0777, true /* recursive */);
     }
     \file_put_contents($path, $content);
+
+    invariant(
+      \file_exists($path) && \file_get_contents($path) === $content,
+      "Failed to update or create %s",
+      $path
+    );
   }
 
   <<__Override>>


### PR DESCRIPTION
Fails on MacOS

Planning to add testing of actual developer flow, so need clean test run
on all platforms :)
