### PR TITLE
regenerate expect/output files if example code changes

### DIFF
--- a/src/markdown-extensions/extracted-code-blocks/ExtractFilter.php
+++ b/src/markdown-extensions/extracted-code-blocks/ExtractFilter.php
@@ -28,7 +28,7 @@ final class ExtractFilter extends FilterBase {
   private static keyset<string> $writtenPaths = keyset[];
 
   <<__Override>>
-  protected static function processFile(string $path, string $content): void {
+  protected static function processFile(string $path, string $content): bool {
     invariant(
       !C\contains_key(self::$writtenPaths, $path),
       'Found multiple code blocks with the same file name: %s',
@@ -37,7 +37,7 @@ final class ExtractFilter extends FilterBase {
     self::$writtenPaths[] = $path;
 
     if (\file_exists($path) && \file_get_contents($path) === $content) {
-      return;
+      return false;
     }
     if (!\file_exists(\dirname($path))) {
       \mkdir(\dirname($path), 0777, true /* recursive */);
@@ -49,6 +49,7 @@ final class ExtractFilter extends FilterBase {
       "Failed to update or create %s",
       $path
     );
+    return true;
   }
 
   <<__Override>>

--- a/src/markdown-extensions/extracted-code-blocks/VerifyFilter.php
+++ b/src/markdown-extensions/extracted-code-blocks/VerifyFilter.php
@@ -24,7 +24,7 @@ final class VerifyFilter extends FilterBase {
   const FIX = 'Run `hhvm bin/build.php` and commit all generated files.';
 
   <<__Override>>
-  protected static function processFile(string $path, string $content): void {
+  protected static function processFile(string $path, string $content): bool {
     invariant(\file_exists($path), '%s is missing. %s', $path, self::FIX);
     invariant(
       \file_get_contents($path) === $content,
@@ -32,6 +32,7 @@ final class VerifyFilter extends FilterBase {
       $path,
       self::FIX,
     );
+    return false;
   }
 
   <<__Override>>


### PR DESCRIPTION
This makes it so that if you update some example code block, running `hhvm bin/build.php` will automatically update the relevant output/expect files.

I originally intentionally avoided doing this, but it ended up being pretty annoying for anyone working on a new guide and iterating on their example code (they'd have to manually delete the correct output files from the build directory after each change), so it was probably the wrong decision.

The tradeoff here (and the reason why I originally didn't want to do this) is that if someone updates some example code block and *doesn't* expect the output to change (e.g. fixing style, improving readability, making it compatible with latest HHVM...), it is now possible that the output will change without them noticing. However, we still require any changes to output/expect files to be committed, so hopefully it would still be caught later when creating/reviewing a PR.