### PR TITLE
[enum class] Updating constructors to be ready for coeffects

### DIFF
--- a/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassBox.definition.hack
+++ b/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassBox.definition.hack
@@ -6,7 +6,7 @@ namespace HHVM\UserDocumentation\Guides\Hack\BuiltInTypes\EnumClass\EnumClassBox
 interface IBox {}
 
 class Box<T> implements IBox {
-  public function __construct(public T $data) {}
+  public function __construct(public T $data)[] {}
 }
 
 enum class Boxes : IBox {

--- a/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassIntro.hack
+++ b/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassIntro.hack
@@ -21,7 +21,7 @@ interface IHasName {
 }
 
 class HasName implements IHasName {
-  public function __construct(private string $name) {}
+  public function __construct(private string $name)[] {}
   public function name() : string {
     return $this->name;
   }

--- a/guides/hack/11-built-in-types/35-enum-class.md
+++ b/guides/hack/11-built-in-types/35-enum-class.md
@@ -29,7 +29,7 @@ interface IHasName {
 }
 
 class HasName implements IHasName {
-  public function __construct(private string $name) {}
+  public function __construct(private string $name)[] {}
   public function name() : string {
     return $this->name;
   }
@@ -161,7 +161,7 @@ As explained in the introduction, this feature also allows to write dependently 
 interface IBox {}
 
 class Box<T> implements IBox {
-  public function __construct(public T $data) {}
+  public function __construct(public T $data)[] {}
 }
 
 enum class Boxes : IBox {


### PR DESCRIPTION
Activating coeffects will require all initializers to be at most
`write_props`. Here, pure is fine for most of them