### PR TITLE
retry failed examples with updated autoload map

### DIFF
--- a/src/build/UpdateAutoloaderBuildStep.php
+++ b/src/build/UpdateAutoloaderBuildStep.php
@@ -22,6 +22,10 @@ final class UpdateAutoloaderBuildStep extends BuildStep {
   <<__Override>>
   public function buildAll(): void {
     Log::i("UpdateAutoloaderBuildStep\n");
+    self::generateAutoloadMap();
+  }
+
+  public static function generateAutoloadMap(): void {
     $dev = \Facebook\AutoloadMap\Generated\is_dev();
     $importer = new RootImporter(
       LocalConfig::ROOT,


### PR DESCRIPTION
If you add multiple example code blocks that depend on each other (e.g. class definition + usage), running `hhvm bin/build.php` will likely result in "undefined class" errors when it runs the 2nd example (particularly annoying because re-running the build won't fix it unless you make some changes to the examples or manually delete the generated files). This should fix it.