### PR TITLE
Remove stale min-versions metadata

### DIFF
--- a/guides/hack/12-generics/20-reified-generics.md
+++ b/guides/hack/12-generics/20-reified-generics.md
@@ -1,8 +1,3 @@
-```yamlmeta
-{
-  "min-versions": { "HHVM": "4.17" }
-}
-```
 # Reified Generics
 
 A _Reified Generic_ is a [Generic](http://localhost:8080/hack/generics/some-basics) with type information accessible at runtime.

--- a/guides/hack/15-asynchronous-operations/14-concurrent.md
+++ b/guides/hack/15-asynchronous-operations/14-concurrent.md
@@ -1,9 +1,3 @@
-```yamlmeta
-{
-  "min-versions": { "HHVM": "4.6" }
-}
-```
-
 `concurrent` concurrently awaits all `await`s within a `concurrent` block and it works with [`await`-as-an-expression](await-as-an-expression.md) as well!
 
 Note: [concurrent doesn't mean multithreading](some-basics#limitations)

--- a/guides/hack/15-asynchronous-operations/15-await-as-an-expression.md
+++ b/guides/hack/15-asynchronous-operations/15-await-as-an-expression.md
@@ -1,9 +1,3 @@
-```yamlmeta
-{
-  "min-versions": { "HHVM": "4.6" }
-}
-```
-
 To strike a balance between flexibility, latency, and performance, we require that the `await`s only appear in **unconditionally consumed expression positions**. This means that from the closest statement, the result of the `await` must be used under all non-throwing cases. This is important because all `await`s for a statement will run together, we don't want to over-run code if its result might not be utilized.
 
 All `await`s within the same statement will execute concurrently.


### PR DESCRIPTION
fixes #1005

The feature is now unused, but should probably be added for coeffects
