### PR TITLE
don't auto-linkify inside links

### DIFF
--- a/guides/hack/15-asynchronous-operations/19-extensions.md
+++ b/guides/hack/15-asynchronous-operations/19-extensions.md
@@ -194,7 +194,7 @@ MCRouter is a memcached protocol-routing library. To help with  [memcached](http
 provides features such as connection pooling and prefix-based routing.
 
 The async MCRouter extension is basically an async subset of the Memcached extension that is part of HHVM. The primary class is
-[`MCRouter`](../reference/class/MCRouter/). There are two ways to create an instance of an MCRouter object. The
+`MCRouter`. There are two ways to create an instance of an MCRouter object. The
 [`createSimple`](../reference/class/MCRouter/createSimple/) method takes a vector of server addresses where memcached is running. The
 more configurable [`__construct`](../reference/class/MCRouter/__construct/) method allows for more option tweaking. After getting an object,
 we can use the `async` versions of the core memcached protocol methods like [`add`](../reference/class/MCRouter/add/),


### PR DESCRIPTION
This is a short but kinda ugly solution...is there a better way?

A slightly better (but still pretty ugly) solution would be to pass a modified `$context` to `Inlines\Link`, but the context class only has a method to add more Inlines, not remove them; also it's mutable so modifying it in the middle of parsing seems even more dangerous than this version :(