### PR TITLE
support classes in api-examples

### DIFF
--- a/api-examples/class.HH.Set.md
+++ b/api-examples/class.HH.Set.md
@@ -1,0 +1,3 @@
+More documentation and examples are in the
+[`Set` and `ImmSet`](/hack/arrays-and-collections/collections#set-and-immset)
+guide.

--- a/src/hh-apidoc-extensions/MarkdownBuilder.php
+++ b/src/hh-apidoc-extensions/MarkdownBuilder.php
@@ -20,7 +20,10 @@ final class MarkdownBuilder extends HHAPIDoc\DocumentationBuilder {
   ): keyset<classname<HHAPIDoc\PageSections\PageSection>> {
     $inherited = Keyset\filter(
       parent::getPageSections(),
-      $section ==> $section !== HHAPIDoc\PageSections\NameHeading::class,
+      $section ==>
+        $section !== HHAPIDoc\PageSections\NameHeading::class &&
+        // InterfaceSynopsis moved to the bottom (see below)
+        $section !== HHAPIDoc\PageSections\InterfaceSynopsis::class,
     );
     $sections = Vec\concat(
       vec[
@@ -29,6 +32,7 @@ final class MarkdownBuilder extends HHAPIDoc\DocumentationBuilder {
       $inherited,
       vec[
         PageSections\Examples::class,
+        HHAPIDoc\PageSections\InterfaceSynopsis::class,
       ],
     );
     // Insert "Guides" after description.

--- a/src/hh-apidoc-extensions/PageSections/Examples.php
+++ b/src/hh-apidoc-extensions/PageSections/Examples.php
@@ -11,6 +11,7 @@
 
 namespace HHVM\UserDocumentation\HHAPIDocExt\PageSections;
 
+use type Facebook\DefinitionFinder\{ScannedClassish, ScannedFunction};
 use type Facebook\HHAPIDoc\PageSections\PageSection;
 use type HHVM\UserDocumentation\BuildPaths;
 use namespace HH\Lib\Str;
@@ -20,8 +21,16 @@ final class Examples extends PageSection {
   public function getMarkdown(): ?string {
     if ($this->parent !== null) {
       $subdirectory = 'class.'.$this->parent->getName().'/';
-    } else {
+    } else if ($this->definition is ScannedClassish) {
+      $subdirectory = 'class.';
+    } else if ($this->definition is ScannedFunction) {
       $subdirectory = 'function.';
+    } else {
+      invariant_violation(
+        'Please add support for definitions of type %s to %s.',
+        \get_class($this->definition),
+        __METHOD__,
+      );
     }
     $subdirectory .= $this->definition->getName();
 


### PR DESCRIPTION
The "Examples" section can now also be added to class/interface reference pages, not just functions and methods.

![Screen Shot 2021-03-31 at 12 47 03-fullpage](https://user-images.githubusercontent.com/2483917/113047700-7de05180-9156-11eb-9b11-93f86cbfceaf.png)
