### PR TITLE
Clearing up the proper use of true/false in hack

### DIFF
--- a/guides/hack/11-built-in-types/04-bool.md
+++ b/guides/hack/11-built-in-types/04-bool.md
@@ -1,4 +1,4 @@
-The Boolean type `bool` can store two distinct values, which correspond to the Boolean values True and False, respectively.
+The Boolean type `bool` can store two distinct values, which correspond to the Boolean values `true` and `false`, respectively.
 
 Consider the following example:
 


### PR DESCRIPTION
While helping a teammate out with hack (coming from python), we noticed that true and false were capitalized which isn't how hack has those values as. Just trying to make the documentation a bit clearer.