### PR TITLE
Hhvm 4.102 is lts, not 4.104

### DIFF
--- a/guides/hhvm/01-installation/06-release-schedule.md
+++ b/guides/hhvm/01-installation/06-release-schedule.md
@@ -14,7 +14,9 @@ Here's a table of recent LTS releases as well as *expected* future LTS releases:
 | 4.32    | November 19th, 2019     | October 21st, 2020         |
 | 4.56    | May 4th, 2020           | April 5th, 2021            |
 | 4.80    | October 21st, 2020      | *September 22nd, 2021*     | 
-| 4.104   | *April 5th, 2021*       | *March 7th, 2022*          |
+| 4.102!! | March 23rd, 2021        | *March 7th, 2022*          |
 | 4.128   | *September 22nd, 2021*  | *August 24th, 2022*        |
 
 \* *Dates in italics signify an **expected** date.*
+
+!! Hhvm 4.102 was promoted to lts status instead of hhvm 4.104. Its expected support duration has been extended by 2 weeks (to a total of 50) to compensate for the "early start". See the [blog post](https://hhvm.com/blog/2021/03/29/extending-hhvm-4.102-support.html) for more information.


### PR DESCRIPTION
Took the start date of the release of hhvm 4.102 instead of the date at which ltsness was announced. Also removed italics for start date with the power of hindsight.