### PR TITLE
Move away from classic EC2 (deprecated), use Terraform

### DIFF
--- a/.deploy/terraform/.gitignore
+++ b/.deploy/terraform/.gitignore
@@ -1,0 +1,3 @@
+terraform.tfvars
+.terraform/
+.terraform.lock.hcl

--- a/.deploy/terraform/application_version.json.tpl
+++ b/.deploy/terraform/application_version.json.tpl
@@ -1,0 +1,11 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "hhvm/user-documentation:${image_tag}"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "80"
+    }
+  ]
+}

--- a/.deploy/terraform/docs.tf
+++ b/.deploy/terraform/docs.tf
@@ -280,10 +280,3 @@ resource "aws_elastic_beanstalk_configuration_template" "docs" {
   }
 }
 
-resource "aws_elastic_beanstalk_environment" "docs_a" {
-  application = aws_elastic_beanstalk_application.docs.name
-  name = "hhvm-hack-docs-vpc-a"
-  cname_prefix = "hack-hhvm-docs-vpc-staging"
-  template_name = aws_elastic_beanstalk_configuration_template.docs.name
-  version_label = "app-1ef9-210727_182110-stage-210727_182110"
-}

--- a/.deploy/terraform/docs.tf
+++ b/.deploy/terraform/docs.tf
@@ -1,0 +1,233 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+  default_tags {
+    tags = {
+      Creator = "Terraform"
+    }
+  }
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "Hack/HHVM docs"
+  }
+  assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_subnet" "az_a" {
+  vpc_id = aws_vpc.main.id
+  cidr_block = "10.0.0.0/24"
+  availability_zone = "us-west-2c"
+  tags = {
+    Name = "Hack/HHVM docs AZ a"
+  }
+  map_public_ip_on_launch = true
+}
+
+resource "aws_subnet" "az_b" {
+  vpc_id = aws_vpc.main.id
+  cidr_block = "10.0.1.0/24"
+  availability_zone = "us-west-2a"
+  tags = {
+    Name = "Hack/HHVM docs AZ b"
+  }
+  map_public_ip_on_launch = true
+}
+  
+
+resource "aws_security_group" "internal" {
+  name = "Hack/HHVM docs internal"
+  vpc_id = aws_vpc.main.id
+  ingress {
+    description = "SSH"
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
+  ingress {
+    description = "HTTP"
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = [ "0.0.0.0/0" ]
+    ipv6_cidr_blocks = [ "::/0" ]
+  }
+  tags = {
+    Name = "Hack/HHVM docs internal"
+  }
+}
+
+resource "aws_security_group" "public" {
+  name = "Hack/HHVM docs public"
+  vpc_id = aws_vpc.main.id
+  ingress {
+    description = "HTTP"
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  ingress {
+    description = "HTTPS"
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = [ "0.0.0.0/0" ]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  tags = {
+    Name = "Hack/HHVM docs LB"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "Hack/HHVM docs IGW"
+  }
+}
+
+resource "aws_elastic_beanstalk_application" "docs" {
+  name = "hhvm-hack-docs"
+  appversion_lifecycle {
+    delete_source_from_s3 = true
+    max_age_in_days       = 0
+    max_count             = 200
+    service_role          = "arn:aws:iam::223121549624:role/aws-elasticbeanstalk-service-role"
+  }
+}
+
+resource "aws_elastic_beanstalk_environment" "docs_a" {
+  name = "hhvm-hack-docs-vpc-a"
+  application = aws_elastic_beanstalk_application.docs.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.4.3 running Docker"
+  cname_prefix = "hack-hhvm-docs-vpc-staging"
+  ///// Environment and Instances ////
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name = "EC2KeyName"
+    value = "hhvm-package-builders"
+  }
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name = "IamInstanceProfile"
+    value = "aws-elasticbeanstalk-ec2-role"
+  }
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name = "InstanceType"
+    value = "t3.micro"
+  }
+  setting {
+    namespace = "aws:ec2:vpc"
+    name = "VPCId"
+    value = aws_vpc.main.id
+  }
+  setting {
+    namespace = "aws:ec2:vpc"
+    name = "Subnets"
+    value = join(",", [aws_subnet.az_a.id, aws_subnet.az_b.id])
+  }
+  setting {
+    namespace = "aws:ec2:vpc"
+    name = "ELBSubnets"
+    value = join(",", [aws_subnet.az_a.id, aws_subnet.az_b.id])
+  }
+  ///// Scaling /////
+  setting {
+    namespace = "aws:autoscaling:trigger"
+    name = "MeasureName"
+    value = "Latency"
+  }
+  setting {
+    namespace = "aws:autoscaling:trigger"
+    name = "Unit"
+    value = "Seconds"
+  }
+  setting {
+    namespace = "aws:autoscaling:trigger"
+    name = "LowerThreshold"
+    value = "1"
+  }
+  setting {
+    namespace = "aws:autoscaling:trigger"
+    name = "UpperThreshold"
+    value = "3"
+  }
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name = "MinSize"
+    value = "1"
+  }
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name = "MaxSize"
+    value = "4"
+  }
+  ///// Load Balancing /////
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name = "EnvironmentType"
+    value = "LoadBalanced"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name = "LoadBalancerType"
+    value = "application"
+  }
+  setting {
+    namespace = "aws:elbv2:loadbalancer"
+    name = "ManagedSecurityGroup"
+    value = aws_security_group.public.id
+  }
+  setting {
+    namespace = "aws:elbv2:loadbalancer"
+    name = "SecurityGroups"
+    value = join(",", [aws_security_group.public.id, aws_security_group.internal.id])
+  }
+  setting {
+    namespace = "aws:elbv2:listener:80"
+    name = "listenerEnabled"
+    value = "true"
+  }
+  setting {
+    namespace = "aws:elbv2:listener:443"
+    name = "listenerEnabled"
+    value = "true"
+  }
+  setting {
+    namespace = "aws:elbv2:listener:443"
+    name = "Protocol"
+    value = "HTTPS"
+  }
+  setting {
+    namespace = "aws:elbv2:listener:443"
+    name = "SSLCertificateArns"
+    value = "arn:aws:acm:us-west-2:223121549624:certificate/8f845b56-937f-49b8-adf4-64b69a3caf57"
+  }
+}

--- a/.deploy/terraform/main.tf
+++ b/.deploy/terraform/main.tf
@@ -5,6 +5,12 @@ terraform {
       version = "~> 3.0"
     }
   }
+  backend "s3" {
+    region = "us-west-2"
+    bucket = "hack-docs-terraform-state"
+    key = "hack-docs/tfstate"
+    dynamodb_table = "hack-docs-tfstate"
+  }
 }
 
 provider "aws" {

--- a/.deploy/terraform/main.tf
+++ b/.deploy/terraform/main.tf
@@ -1,3 +1,12 @@
+##### WARNING #####
+# The ElasticBeanstalk IPAddressType and SecurityGroup settings for load
+# balancers are currently silently ignored by AWS.
+#
+# If you are using this to set up a new instance, you'll need to:
+# - change the s3 bucket used for state to one you control
+# - manually change the load balancers to dual stack and set the security group
+#
+# Otherwise connections from the internet will be dropped.
 terraform {
   required_providers {
     aws = {
@@ -243,11 +252,6 @@ resource "aws_elastic_beanstalk_configuration_template" "docs" {
     namespace = "aws:elasticbeanstalk:environment"
     name = "LoadBalancerType"
     value = "application"
-  }
-  setting {
-    namespace = "aws:elbv2:loadbalancer"
-    name = "ManagedSecurityGroup"
-    value = aws_security_group.public.id
   }
   setting {
     namespace = "aws:elbv2:loadbalancer"

--- a/.deploy/terraform/prod.tf
+++ b/.deploy/terraform/prod.tf
@@ -1,7 +1,34 @@
+variable "prod_docker_image" {
+  type = string
+}
+
+data "template_file" "prod_appversion" {
+  template = "${file("application_version.json.tpl")}"
+  vars = {
+    image_tag = var.prod_docker_image
+  }
+}
+
+resource "aws_s3_bucket_object" "prod_appversion" {
+  bucket = "hack-docs-terraform-state"
+  key = "hack-docs/prod-versions/${var.prod_docker_image}.json"
+  content = data.template_file.prod_appversion.rendered
+}
+
+resource "aws_elastic_beanstalk_application_version" "docs_prod" {
+  application = aws_elastic_beanstalk_application.docs.name
+  name = "tf-prod-${var.prod_docker_image}"
+  bucket = aws_s3_bucket_object.prod_appversion.bucket
+  key = aws_s3_bucket_object.prod_appversion.id
+}
+
 resource "aws_elastic_beanstalk_environment" "docs_prod" {
   application = aws_elastic_beanstalk_application.docs.name
   name = "hhvm-hack-docs-vpc-prod"
   cname_prefix = "hack-hhvm-docs-vpc-prod"
   template_name = aws_elastic_beanstalk_configuration_template.docs.name
-  version_label = "app-1ef9-210727_182110-stage-210727_182110"
+  version_label = aws_elastic_beanstalk_application_version.docs_prod.id
+  tags = {
+    DockerImage = var.prod_docker_image
+  }
 }

--- a/.deploy/terraform/prod.tf
+++ b/.deploy/terraform/prod.tf
@@ -1,0 +1,7 @@
+resource "aws_elastic_beanstalk_environment" "docs_prod" {
+  application = aws_elastic_beanstalk_application.docs.name
+  name = "hhvm-hack-docs-vpc-prod"
+  cname_prefix = "hack-hhvm-docs-vpc-prod"
+  template_name = aws_elastic_beanstalk_configuration_template.docs.name
+  version_label = "app-1ef9-210727_182110-stage-210727_182110"
+}

--- a/.deploy/terraform/staging.tf
+++ b/.deploy/terraform/staging.tf
@@ -1,0 +1,7 @@
+resource "aws_elastic_beanstalk_environment" "docs_staging" {
+  application = aws_elastic_beanstalk_application.docs.name
+  name = "hhvm-hack-docs-vpc-staging"
+  cname_prefix = "hack-hhvm-docs-vpc-staging"
+  template_name = aws_elastic_beanstalk_configuration_template.docs.name
+  version_label = "app-1ef9-210727_182110-stage-210727_182110"
+}

--- a/.deploy/terraform/staging.tf
+++ b/.deploy/terraform/staging.tf
@@ -1,7 +1,34 @@
+variable "staging_docker_image" {
+  type = string
+}
+
+data "template_file" "staging_appversion" {
+  template = "${file("application_version.json.tpl")}"
+  vars = {
+    image_tag = var.staging_docker_image
+  }
+}
+
+resource "aws_s3_bucket_object" "staging_appversion" {
+  bucket = "hack-docs-terraform-state"
+  key = "hack-docs/staging-versions/${var.staging_docker_image}.json"
+  content = data.template_file.staging_appversion.rendered
+}
+
+resource "aws_elastic_beanstalk_application_version" "docs_staging" {
+  application = aws_elastic_beanstalk_application.docs.name
+  name = "tf-staging-${var.staging_docker_image}"
+  bucket = aws_s3_bucket_object.staging_appversion.bucket
+  key = aws_s3_bucket_object.staging_appversion.id
+}
+
 resource "aws_elastic_beanstalk_environment" "docs_staging" {
   application = aws_elastic_beanstalk_application.docs.name
   name = "hhvm-hack-docs-vpc-staging"
   cname_prefix = "hack-hhvm-docs-vpc-staging"
   template_name = aws_elastic_beanstalk_configuration_template.docs.name
-  version_label = "app-1ef9-210727_182110-stage-210727_182110"
+  version_label = aws_elastic_beanstalk_application_version.docs_staging.id
+  tags = {
+    DockerImage = var.staging_docker_image
+  }
 }

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -142,7 +142,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
       - name: Install Terraform
-        with: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v1
       - name: Initialize Terraform
         run: (cd .deploy/terraform; terraform init)
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -141,6 +141,24 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      - name: Install Terraform
+        with: hashicorp/setup-terraform@v1
+      - name: Initialize Terraform
+        run: (cd .deploy/terraform; terraform init)
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      - name: Deploy to staging environment (Terraform)
+        run: |
+          PROD_TAG=$(eb tags hhvm-hack-docs-vpc-prod -l | awk '/DockerImage/{print $NF}')
+          echo "Current prod tag: ${PROD_TAG}"
+          (
+            cd .deploy/terraform
+            terraform "-var=prod_docker_image=${PROD_TAG}" "-var=staging_docker_image=${IMAGE_TAG}" apply --auto-approve
+          )
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
       - name: Run test suite against staging
         run: |
           docker run --rm \
@@ -152,6 +170,15 @@ jobs:
            tests/
       - name: Swap staging and prod
         run: eb swap
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      - name: Deploy to prod (Terraform)
+        run: |
+          (
+            cd .deploy/terraform
+            terraform "-var=prod_docker_image=${IMAGE_TAG}" "-var=staging_docker_image=${IMAGE_TAG}" apply --auto-approve
+          )
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}


### PR DESCRIPTION
- EC2 classic (without VPCs) is being removed. Our current ElasticBeanstalk setup is based on EC2 classic
- Used terraform to setup two new EB environments that are using VPCs
- Modified github actions to attempt to push to the new VPC config using terraform as well as keeping the existing push process

Once the new environments are being pushed, I'll remove the classic environments.