### PR TITLE
Fixes #1052: Rewrite of Pipe operator page

### DIFF
--- a/guides/hack/03-expressions-and-operators/93-pipe.md
+++ b/guides/hack/03-expressions-and-operators/93-pipe.md
@@ -1,14 +1,14 @@
 The binary pipe operator, `|>`, evaluates the result of a left-hand expression and stores the result in `$$`, the pre-defined pipe variable. The right-hand expression *must* contain at least one occurrence of `$$`.
 
-For example, the code below ...
+With the pipe operator, you can chain function calls, as shown in the code below.
 
 ``` Hack
 $x = vec[2,1,3]
-  |> Vec\map($$, $a ==> $a * $a) // $$ with value [2,1,3]
-  |> Vec\sort($$); // $$ with value [4,1,9]
+  |> Vec\map($$, $a ==> $a * $a) // $$ with value vec[2,1,3]
+  |> Vec\sort($$); // $$ with value vec[4,1,9]
 ```
 
-... is functionally equivalent to:
+Written in another way, the code above is syntactically equivalent to:
 
 ``` Hack
 Vec\sort(Vec\map(vec[2, 1, 3], $a ==> $a * $a)) // Evaluates to vec[1,4,9]


### PR DESCRIPTION
- Remove incorrect line: "A pipe expression *cannot* be used as the right-hand operand of an assignment operator."
- Remove section on Sequence Points, which seems to not be relevant.
- Add functionality equivalent code example.

![image](https://user-images.githubusercontent.com/5179225/131007316-280789df-71f3-46a7-84de-a4270a51a994.png)
