### PR TITLE
fix output highlighting after highlightjs

### DIFF
--- a/sass/codeBlocks.scss
+++ b/sass/codeBlocks.scss
@@ -25,6 +25,6 @@ p + .highlight {
   }
 }
 
-.output-block span{
+.output-block span {
   color: inherit;
 }

--- a/sass/codeBlocks.scss
+++ b/sass/codeBlocks.scss
@@ -24,3 +24,7 @@ p + .highlight {
     font-size: 60%;
   }
 }
+
+.output-block span{
+  color: inherit;
+}

--- a/src/markdown-extensions/PrettyCodeBlocksFilter.php
+++ b/src/markdown-extensions/PrettyCodeBlocksFilter.php
@@ -47,6 +47,8 @@ final class PrettyCodeBlocksFilter extends RenderFilter {
 
       $classes .= ' source-language-'.$info_string;
       $info_string = 'PHP';
+    } else {
+      $classes .= ' output-block';
     }
 
     return vec[


### PR DESCRIPTION
Add a class for output blocks, then revert color to remove keyword highlighting in output text.

Ref: #826 

# Example 1
<img width="1216" alt="Screen Shot 2021-09-10 at 12 24 09 AM" src="https://user-images.githubusercontent.com/5179225/132799929-7415faa8-692f-44fc-afec-2a715ab36840.png">
<img width="1262" alt="Screen Shot 2021-09-10 at 12 24 54 AM" src="https://user-images.githubusercontent.com/5179225/132799931-0ebb2a73-8e08-437e-8009-3eabb01f901d.png">

# Example 2
<img width="1228" alt="Screen Shot 2021-09-10 at 12 26 47 AM" src="https://user-images.githubusercontent.com/5179225/132799987-08c6951c-20ff-4043-922d-a0de00b9b5ea.png">
<img width="1253" alt="Screen Shot 2021-09-10 at 12 26 20 AM" src="https://user-images.githubusercontent.com/5179225/132799986-5e9349d0-e41d-4e35-911e-89377ac63377.png">

# Example 3
<img width="1281" alt="Screen Shot 2021-09-10 at 12 27 15 AM" src="https://user-images.githubusercontent.com/5179225/132799994-d98e00aa-f2cc-41e3-ae04-fcb46b67acb5.png">
<img width="1249" alt="Screen Shot 2021-09-10 at 12 28 09 AM" src="https://user-images.githubusercontent.com/5179225/132799996-4967a791-14a2-4191-9087-b48a2d00451b.png">
