### PR TITLE
Section for Experimental features + readonly docs

### DIFF
--- a/guides/hack/51-experimental-features/01-introduction.md
+++ b/guides/hack/51-experimental-features/01-introduction.md
@@ -1,0 +1,17 @@
+The following pages of documentation describe Hack language features in the *experimental* phase.
+
+## About Experimental Features
+We _do not_ recommend using any of these features until they are formally announced and integrated into the main documentation set.
+
+## Enabling an Experimental Feature
+To use an experimental feature, add the `__EnableUnstableFeatures` file attribute to any files containing that feature.
+
+```
+<<file:__EnableUnstableFeatures('experimental_feature_name')>>
+```
+
+You can also specify multiple features:
+
+```
+<<file:__EnableUnstableFeatures('experimental_feature_name', 'other_experimental_feature_name')>>
+```

--- a/guides/hack/51-experimental-features/01-introduction.md
+++ b/guides/hack/51-experimental-features/01-introduction.md
@@ -1,6 +1,8 @@
 The following pages of documentation describe Hack language features in the *experimental* phase.
 
 ## About Experimental Features
+We have documented these features as they may appear in built-ins, including the Hack Standard Library.
+
 We _do not_ recommend using any of these features until they are formally announced and integrated into the main documentation set.
 
 ## Enabling an Experimental Feature

--- a/guides/hack/51-experimental-features/02-read-only.md
+++ b/guides/hack/51-experimental-features/02-read-only.md
@@ -42,6 +42,9 @@ function test(readonly Bar $x) : void {
 }
 ```
 
+## How is it different from Coeffects?
+[Coeffects](https://docs.hhvm.com/hack/contexts-and-capabilities/available-contexts-and-capabilities) affects an entire function (and all the functions it calls), whereas readonly affects values / expressions.
+
 ## Applications
 This is a list of all of the valid locations of the keyword.
 
@@ -121,7 +124,7 @@ function foo(): void {
 ```
 
 ### Functions / Methods
-`readonly` can appear as a modifier on instance methods.
+`readonly` can appear as a modifier on instance methods, signaling that `$this` is readonly.
 
 ``` Hack
 class C {
@@ -171,8 +174,8 @@ function returns_mutable(readonly Foo $x): Foo {
 ### Closures
 A function type can be marked readonly: `readonly function(T1): T`.
 
-## Interactions with [Context and Capabilities](https://docs.hhvm.com/hack/contexts-and-capabilities/available-contexts-and-capabilities)
-If your function only has the `ReadGlobals` capability (i.e. is marked `read_globals` or `policied`) it can only access class static variables if they are wrapped in a readonly expression:
+## Interactions with [Coeffects](https://docs.hhvm.com/hack/contexts-and-capabilities/available-contexts-and-capabilities)
+If your function only has the `ReadGlobals` capability (i.e. is marked `read_globals`) it can only access class static variables if they are wrapped in a readonly expression:
 
 ``` Hack
 function read_static()[read_globals]: void {
@@ -198,6 +201,8 @@ function test(): void {
 
 ## Converting to non-readonly
 Sometimes you may encounter a readonly value that isn’t an object (i.e. a readonly int, due to the deepness property of readonly). In those cases, instead of returning a readonly int, you’ll want a way to tell Hack that the value you have is actually a value type. You can use the function `HH\Readonly\as_mut()` to convert any primitive type from readonly to mutable.
+
+Use `HH\Readonly\as_mut()` strictly for primitive types and value-type collections of primitive types (i.e. a vec of int).
 
 ``` Hack
 class Foo {

--- a/guides/hack/51-experimental-features/02-read-only.md
+++ b/guides/hack/51-experimental-features/02-read-only.md
@@ -1,0 +1,213 @@
+This page describes the *readonly* experimental feature.
+
+## What is it?
+`readonly` is a keyword that prohibits mutability on [Objects](https://docs.hhvm.com/hack/classes/introduction) and their properties.
+
+## Enabling readonly
+In your relevant file(s), add `<<file:__EnableUnstableFeatures('readonly')>>`.
+
+## How does it work?
+When an Object has the `readonly` keyword applied (e.g. `private readonly Foo $x;`, there are two new constraints on that Object.
+* **Readonlyness:** Object properties can not be modified (i.e. mutated).
+* **Deepness:** All nested properties are readonly.
+
+### Readonlyness
+Object properties can not be modified (i.e. mutated).
+
+``` Hack
+function test(readonly Foo $x) : void {
+  $x->prop = 4; // error, $x is readonly, its properties can not be modified
+}
+```
+
+### Deepness
+All nested properties are readonly.
+
+``` Hack
+class Bar {
+  public function __construct(
+    public Foo $foo,
+  )
+}
+
+class Foo {
+  public function __construct(
+    public int $prop,
+  )
+}
+
+function test(readonly Bar $x) : void {
+  $foo = $x->foo;
+  $foo->prop = 3; // error, $foo is readonly
+}
+```
+
+## Applications
+This is a list of all of the valid locations of the keyword.
+
+### Parameters and return values
+Parameters and return values of any callable can be marked `readonly`.
+
+``` Hack
+function foo(readonly Foo $x): readonly Bar {
+  return $x->bar;
+}
+```
+
+A readonly *parameter* signals that the function/method will not modify that parameter; a readonly *return type* signals that the function returns a readonly reference to an object that can not be modified.
+
+### Static and regular properties
+Static and regular properties can be marked `readonly` and, when applied, can not be modified.
+
+``` Hack
+class Foo {
+  private readonly Bar $bar;
+  private static readonly Bar $static_bar;
+}
+```
+
+#### Other restrictions
+Accessing a readonly property (i.e. a property that’s marked readonly at the declaration, not accessing a property off of a readonly object) requires readonly annotation.
+
+``` Hack
+class Foo {
+  public function __construct(
+    readonly Bar $bar,
+  )
+}
+
+function test(Foo $f): void {
+  $bar = readonly $f->bar; // this is required
+}
+```
+
+And, class properties can not be set to readonly values unless they are readonly properties.
+
+``` Hack
+class Foo {
+  readonly Bar $ro_prop;
+  Bar $mut_prop;
+}
+
+function test(
+  Foo $x,
+  readonly Bar $bar,
+) : void {
+  $x->mut_prop = $bar; // error, $bar is readonly but the prop is mutable
+  $x->ro_prop = $bar; // ok
+}
+```
+
+### Lambdas and function type signatures
+`readonly` is allowed on inner parameters and return types on function typehints.
+
+``` Hack
+function call(
+    (function(readonly Bar) : readonly Bar) $f,
+    readonly Bar $arg,
+   ) : readonly Bar {
+   return $f($arg);
+}
+```
+
+### Expressions
+`readonly` can appear on expressions.
+
+``` Hack
+function foo(): void {
+  $x = new Foo();
+  $y = readonly $x;
+}
+```
+
+### Functions / Methods
+`readonly` can appear as a modifier on instance methods.
+
+``` Hack
+class C {
+  public readonly function bar(): Bar {
+    return new Bar();
+  }
+  public readonly function foo() : void {
+    $this->prop = 5; // error, $this is readonly.
+  }
+}
+```
+
+#### Other restrictions
+Readonly objects can only call readonly methods.
+
+``` Hack
+class C {
+  public readonly function bar(): Bar {
+    return new Bar();
+  }
+  public readonly function foo() : void {
+    $this->prop = 5; // error, $this is readonly.
+  }
+}
+```
+
+Readonly values can not be passed to a function that takes mutable values.
+
+``` Hack
+function takes_mutable(Foo $x): void {
+  $x->prop = 4;
+}
+
+$z : readonly
+takes_mutable($z); // error, takes_mutable's first parameter
+                   // is mutable, but $z is readonly
+```
+
+And, functions can not return readonly values unless they are marked to return readonly.
+
+``` Hack
+function returns_mutable(readonly Foo $x): Foo {
+  return $x; // error, $x is readonly
+}
+```
+
+### Closures
+A function type can be marked readonly: `readonly function(T1): T`.
+
+## Interactions with [Context and Capabilities](https://docs.hhvm.com/hack/contexts-and-capabilities/available-contexts-and-capabilities)
+If your function only has the `ReadGlobals` capability (i.e. is marked `read_globals` or `policied`) it can only access class static variables if they are wrapped in a readonly expression:
+
+``` Hack
+function read_static()[read_globals]: void {
+  $y = readonly Foo::$bar; // keyword required
+}
+function read_static()[policied]: void {
+  $y = readonly Foo::$bar; // keyword required
+}
+```
+
+### Calling a readonly function
+Calling a function or method that returns readonly requires wrapping the result in a readonly expression.
+
+``` Hack
+function returns_readonly(): readonly Foo {
+  return readonly new Foo();
+}
+
+function test(): void {
+  $x = readonly returns_readonly(); // this is required to call returns_readonly()
+}
+```
+
+## Converting to non-readonly
+Sometimes you may encounter a readonly value that isn’t an object (i.e. a readonly int, due to the deepness property of readonly). In those cases, instead of returning a readonly int, you’ll want a way to tell Hack that the value you have is actually a value type. You can use the function `HH\Readonly\as_mut()` to convert any primitive type from readonly to mutable.
+
+``` Hack
+class Foo {
+  public function __construct(
+    public int $prop,
+  )
+
+  public readonly function get() : int {
+    $result = $this->prop; // here, $result is readonly, but its also an int.
+    return HH\Readonly\as_mut($this->prop); // convert to a non-readonly value
+  }
+}
+```

--- a/guides/hack/51-experimental-features/experimental-features-category.txt
+++ b/guides/hack/51-experimental-features/experimental-features-category.txt
@@ -1,0 +1,1 @@
+Experimental Additions

--- a/guides/hack/51-experimental-features/experimental-features-summary.txt
+++ b/guides/hack/51-experimental-features/experimental-features-summary.txt
@@ -1,0 +1,1 @@
+Experimental features in the Hack language.

--- a/src/site/controllers/GuidesListController.php
+++ b/src/site/controllers/GuidesListController.php
@@ -42,11 +42,13 @@ final class GuidesListController extends WebPageController {
 
     // Hack / HHVM  categories
     $category_root = $root;
+
     $getting_started = <ul class="guideList" />;
     $control_flow = <ul class="guideList" />;
     $classes_interfaces_traits = <ul class="guideList" />;
     $types_generics = <ul class="guideList" />;
     $learn = <ul class="guideList" />;
+    $experimental = <ul class="guideList" />;
 
     foreach ($guides as $guide) {
       $pages = GuidesIndex::getPages($product, $guide);
@@ -57,24 +59,27 @@ final class GuidesListController extends WebPageController {
 
       switch($category){
         case CategoriesHack::GETTING_STARTED:
-	  $category_root = $getting_started;
-	  break;
-	case CategoriesHack::CONTROL_FLOW:
-	  $category_root = $control_flow;
-	  break;
-	case CategoriesHack::CLASSES_INTERFACES_TRAITS:
-	  $category_root = $classes_interfaces_traits;
-	  break;
-	case CategoriesHack::TYPES_GENERICS:
-	  $category_root = $types_generics;
-	  break;
-	case CategoriesHHVM::LEARN:
+          $category_root = $getting_started;
+      	  break;
+      	case CategoriesHack::CONTROL_FLOW:
+      	  $category_root = $control_flow;
+      	  break;
+      	case CategoriesHack::CLASSES_INTERFACES_TRAITS:
+      	  $category_root = $classes_interfaces_traits;
+      	  break;
+      	case CategoriesHack::TYPES_GENERICS:
+      	  $category_root = $types_generics;
+      	  break;
+        case CategoriesHack::EXPERIMENTAL:
+          $category_root = $experimental;
+          break;
+      	case CategoriesHHVM::LEARN:
           $category_root = $learn;
-	  break;
-	default:
-	  $category_root = $root;
-	  break;
-      }
+      	  break;
+      	default:
+      	  $category_root = $root;
+      	  break;
+            }
 
       $category_root->appendChild(
         <li>
@@ -90,7 +95,8 @@ final class GuidesListController extends WebPageController {
       $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::GETTING_STARTED}</h3><div class="guideListWrapper">{$getting_started}</div></li>);
       $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::CONTROL_FLOW}</h3><div class="guideListWrapper">{$control_flow}</div></li>);
       $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::CLASSES_INTERFACES_TRAITS}</h3><div class="guideListWrapper">{$classes_interfaces_traits}</div></li>);
-      $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::TYPES_GENERICS}</h3><div>{$types_generics}</div></li>);
+      $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::TYPES_GENERICS}</h3><div class="guideListWrapper">{$types_generics}</div></li>);
+      $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::EXPERIMENTAL}</h3><div>{$experimental}</div></li>);
     }
 
     if ($product === GuidesProduct::HHVM){

--- a/src/site/controllers/HomePageController.php
+++ b/src/site/controllers/HomePageController.php
@@ -36,6 +36,7 @@ final class HomePageController extends WebPageController {
     $classes_interfaces_traits = <ul class="guideList" />;
     $types_generics = <ul class="guideList" />;
     $learn = <ul class="guideList" />;
+    $experimental = <ul class="guideList" />;
 
     foreach ($guides as $guide) {
       $pages = GuidesIndex::getPages($product, $guide);
@@ -61,6 +62,9 @@ final class HomePageController extends WebPageController {
         case CategoriesHack::TYPES_GENERICS:
           $category_root = $types_generics;
           break;
+        case CategoriesHack::EXPERIMENTAL:
+          $category_root = $experimental;
+          break;
         case CategoriesHHVM::LEARN:
           $category_root = $learn;
           break;
@@ -84,6 +88,7 @@ final class HomePageController extends WebPageController {
       $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::CONTROL_FLOW}</h3><div class="guideListWrapper">{$control_flow}</div></li>);
       $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::CLASSES_INTERFACES_TRAITS}</h3><div class="guideListWrapper">{$classes_interfaces_traits}</div></li>);
       $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::TYPES_GENERICS}</h3><div class="guideListWrapper">{$types_generics}</div></li>);
+      $root->appendChild(<li><h3 class="listTitle">{CategoriesHack::EXPERIMENTAL}</h3><div class="guideListWrapper">{$experimental}</div></li>);
     }
 
     if ($product === GuidesProduct::HHVM){
@@ -127,8 +132,7 @@ final class HomePageController extends WebPageController {
           </h3>
           <p>Full reference docs for all functions, classes, interfaces, and traits in the Hack language.</p>
           <h3 class="listTitle">
-            <a href="/hsl/reference/">Hack Standard Library Reference</a> and <a
-              href="/hsl-experimental/reference/">Experimental Additions</a>
+            <a href="/hsl/reference/">Hack Standard Library Reference</a>
           </h3>
           <p>Full reference docs for all functions, classes, interfaces, and traits in the Hack Standard Library (HSL).</p>
         </div>

--- a/src/typedefs.php
+++ b/src/typedefs.php
@@ -35,6 +35,7 @@ enum CategoriesHack: string as string {
   CONTROL_FLOW = 'Control Flow';
   GETTING_STARTED = 'Getting Started';
   TYPES_GENERICS = 'Types and Generics';
+  EXPERIMENTAL = 'Experimental Additions';
 }
 
 enum CategoriesHHVM: string as string {


### PR DESCRIPTION
New section for experimental features and for the `readonly` experimental keyword. Because of how the site is built, adding the section alongside the API reference is pretty tricky: the pages won't generate as is in the sidebar or render unless they're part of one of the product folders ("hack", "hhvm"), so I moved it as a new section & folder in /hack.

Also: Tightened up language in the readonly keyword file but also prefer someone to scan it for accuracy. Intentionally left out some implementation details / talk.

![image](https://user-images.githubusercontent.com/5179225/135351405-3ca00726-db5d-4e8d-8f03-2dbb8905b236.png)

Q: Is this just FYI or will people be able to actually use this functionality in prod hhvm if the attribute is included?

FYI / Q: Also removed https://docs.hhvm.com/hsl-experimental/reference/ which only renders on the /home page (hack + hhvm) but not /hack individually. It's related to: https://github.com/hhvm/hsl-experimental/. Keep? Remove? Either way, should be on both site controllers or neither site controllers.

FYI / Q: Because these are experimental, assume the code sample checker fails to pass these examples, right? Was having issues... so I just marked examples in the  ``` Hack format instead of using the auto-tested example system, but when / if we merge, these tests should be converted.
