### PR TITLE
Fix classes, interfaces, methods, traits links in HSL sidebar

### DIFF
--- a/src/APINavData.php
+++ b/src/APINavData.php
@@ -12,7 +12,7 @@ namespace HHVM\UserDocumentation;
 
 final class APINavData {
   private APIIndex $index;
-  private string $product;
+  private APIProduct $product;
 
   private function __construct(APIProduct $product) {
     $this->index = APIIndex::get($product);
@@ -54,7 +54,7 @@ final class APINavData {
 
   private function getNavDataForClasses(
     APIDefinitionType $class_type,
-    string $product,
+    APIProduct $product,
   ): NavDataNode {
     $nav_data = dict[];
     $classes = $this->index->getClassIndex($class_type);


### PR DESCRIPTION
Fix an issue where the table of contents only ever links to /hack reference documentation. Check the HREF in the embedded images or test on the live site for for context.

## Current Docs
<img width="1680" alt="Screen Shot 2021-10-07 at 2 32 22 PM" src="https://user-images.githubusercontent.com/5179225/136442494-1739934b-469a-4c8b-aca0-99bd8cd76c4e.png">

## Proposed Fix
<img width="1670" alt="Screen Shot 2021-10-07 at 2 20 47 PM" src="https://user-images.githubusercontent.com/5179225/136442351-05b905c0-af25-4462-b5d6-317bad2112c2.png">
ed