### PR TITLE
fix typo in command line basic usage docs. fix.php should read fix.hack

### DIFF
--- a/guides/hhvm/02-basic-usage/02-command-line.md
+++ b/guides/hhvm/02-basic-usage/02-command-line.md
@@ -24,7 +24,7 @@ At the command-line, you would execute the script as follows:
 % hhvm /path/to/fib.hack 10
 ```
 
-You specify the `hhvm` binary, the path to `fib.php` and an argument to the script (arguments to scripts do not exist in all cases, of course).
+You specify the `hhvm` binary, the path to `fib.hack` and an argument to the script (arguments to scripts do not exist in all cases, of course).
 
 ```
 The 10 number in fibonacci is: 55


### PR DESCRIPTION
This Pull Request fixes a small typo in the command line basic usage documentation. `fix.php` should have read `fix.hack`