### PR TITLE
Proposal: Add collapse for non-active nav groups

### DIFF
--- a/sass/navigation.scss
+++ b/sass/navigation.scss
@@ -22,9 +22,8 @@
       .subList {
         display: block;
       }
-
-      h4 > a {
-        text-transform: uppercase;
+      h4 {
+        background-color: #DADADA;
       }
     }
 
@@ -45,7 +44,7 @@
         font-size: 16px;
 
         a {
-          color: $darkblue;
+          color: $orange;
           padding-bottom: 10px;
           padding-top: 10px;
         }


### PR DESCRIPTION
Was talking with @Wilfred about the benefits of a collapsible sidebar because there are so many elements on the left-hand side that it's sort of an endless scroll. Open to suggestions / any thoughts on current v. proposed. For section readability, considering adding horizontal rows or alternating backgrounds. 

Also... in sidebar, $orange is hard for me to read, so I'm using $blue instead.

Having concerns about hiding too much though. What're all of your thoughts.

## Proposed / Sidebar
<img width="1667" alt="Screen Shot 2021-10-11 at 8 30 01 PM" src="https://user-images.githubusercontent.com/5179225/136870924-cfac76b4-7fd8-4d65-971b-f45c57ebc692.png">

## Proposed / Reference Sidebar
![image](https://user-images.githubusercontent.com/5179225/136871003-3d056c1a-6fb8-43d0-ab1d-670c2bd7a603.png)

## Curent Sidebar
![image](https://user-images.githubusercontent.com/5179225/136871129-9753804b-d447-4d09-b8b6-21f58834b1d5.png)
