### PR TITLE
fixes broken link on "Built In Types: Darray Varray Runtime Options"

### DIFF
--- a/guides/hack/11-built-in-types/56-darray-varray-runtime-options.md
+++ b/guides/hack/11-built-in-types/56-darray-varray-runtime-options.md
@@ -1,4 +1,4 @@
-As of [HHVM 4.103](https://hhvm.com/blog/2021/03/31/hhvm-4.103.html), `darray` / `varray` are aliased to `dict` / `vec` respectively. Use [Hack arrays](http://localhost:8080/hack/arrays-and-collections/hack-arrays).
+As of [HHVM 4.103](https://hhvm.com/blog/2021/03/31/hhvm-4.103.html), `darray` / `varray` are aliased to `dict` / `vec` respectively. Use [Hack arrays](https://docs.hhvm.com/hack/arrays-and-collections/hack-arrays).
 
 ## WARNING WARNING WARNING
 

--- a/guides/hack/11-built-in-types/56-darray-varray-runtime-options.md
+++ b/guides/hack/11-built-in-types/56-darray-varray-runtime-options.md
@@ -1,4 +1,4 @@
-As of [HHVM 4.103](https://hhvm.com/blog/2021/03/31/hhvm-4.103.html), `darray` / `varray` are aliased to `dict` / `vec` respectively. Use [Hack arrays](https://docs.hhvm.com/hack/arrays-and-collections/hack-arrays).
+As of [HHVM 4.103](https://hhvm.com/blog/2021/03/31/hhvm-4.103.html), `darray` / `varray` are aliased to `dict` / `vec` respectively. Use [Hack arrays](/hack/arrays-and-collections/hack-arrays).
 
 ## WARNING WARNING WARNING
 


### PR DESCRIPTION
Closes #1102. Relatively self-explanatory; let me know if I should instead be prepending something else instead of the live domain name!