### PR TITLE
dev container

### DIFF
--- a/.deploy/built-site.Dockerfile
+++ b/.deploy/built-site.Dockerfile
@@ -1,6 +1,6 @@
 # Creates a docker image with a built copy of the site. Not repo-auth.
 # Useful as a scratch/testing area.
-FROM hhvm/hhvm:4.130-latest
+FROM hhvm/hhvm:4.134-latest
 ARG DOCKER_BUILD_ENV=prod
 ENV TZ UTC
 ENV DEBIAN_FRONTEND noninteractive

--- a/.deploy/init.sh
+++ b/.deploy/init.sh
@@ -20,14 +20,14 @@ locale-gen en_US.UTF-8
 
 echo "** Installing composer"
 mkdir /opt/composer
-wget -qO /dev/stdout https://getcomposer.org/installer | php -- --install-dir=/opt/composer
-if [ ! -e /opt/composer/composer.phar ]; then
+wget -qO /dev/stdout https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+if [ ! -x /usr/local/bin/composer ]; then
   echo "Failed to install composer"
   exit 1
 fi
 
 echo "** Installing Hack dependencies"
-php /opt/composer/composer.phar install
+composer install
 
 echo "** Run build"
 hhvm bin/build.php --auto

--- a/.deploy/prod.Dockerfile
+++ b/.deploy/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM hhvm/hhvm-proxygen:4.130-latest
+FROM hhvm/hhvm-proxygen:4.134-latest
 
 ADD hhvm.prod.ini /etc/hhvm/site.ini
 ADD hhvm.hhbc /var/www/hhvm.hhbc

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "docs.hhvm.com",
+  "runArgs": [
+    "--init"
+  ],
+  "image": "hhvm/hhvm:4.134-latest",
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+	"terminal.integrated.profiles.linux": {
+		"bash": {
+			"path": "/bin/bash",
+			"args": [
+				"--login"
+			]
+		}
+	},
+	"terminal.integrated.defaultProfile.linux": "bash"
+},
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+	"pranayagarwal.vscode-hack",
+],
+
+  "postCreateCommand": "touch /docker_build; .deploy/init.sh",
+  "postStartCommand": "cd public; hhvm -m server -p 8080 -vServer.AllowRunAsRoot=1 -c ../hhvm.dev.ini",
+  "forwardPorts": [	8080 ]
+}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu ]
-        hhvm: [ '4.130' ]
+        hhvm: [ '4.134' ]
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@v2

--- a/build/extracted-examples/guides/hack/02-source-code-fundamentals/10-comments/show-comment-styles.hack
+++ b/build/extracted-examples/guides/hack/02-source-code-fundamentals/10-comments/show-comment-styles.hack
@@ -5,8 +5,6 @@ namespace HHVM\UserDocumentation\Guides\Hack\SourceCodeFundamentals\Comments\Sho
 
 // A single line comment.
 
-# Also a single line comment.
-
 /* A multi line comment.
  *
  */

--- a/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassFull.user0.hack.hhvm.expectf
+++ b/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassFull.user0.hack.hhvm.expectf
@@ -1,2 +1,1 @@
-
-Fatal error: Undefined enum: HHVM\UserDocumentation\Guides\Hack\BuiltInTypes\EnumClass\EnumClassFull\EKeys in %s/EnumClassFull.user0.hack on line 15
+Fatal error: unknown class HHVM\UserDocumentation\Guides\Hack\BuiltInTypes\EnumClass\EnumClassFull\Key in %s/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassFull.user0.hack on line 8

--- a/build/extracted-examples/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities/write-props-bad.hack.type-errors.example.typechecker.out
+++ b/build/extracted-examples/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities/write-props-bad.hack.type-errors.example.typechecker.out
@@ -1,12 +1,5 @@
-File "/home/example/write-props-bad.hack", line 11, characters 5-12:
-This object's property is being mutated (used as an lvalue)
-Setting non-mutable object properties requires the capability WriteProperty, which is not provided by the context. (Typing[4401])
-  File "/home/example/write-props-bad.hack", line 10, characters 31-32:
-  The local (enclosing) context provides the capability set {}
+File "/home/example/write-props-bad.hack", line 11, characters 5-37:
+Writing to object properties in a pure function is not allowed. (Parsing[1002])
 
-File "/home/example/write-props-bad.hack", line 16, characters 3-8:
-This object's property is being mutated (used as an lvalue)
-Setting non-mutable object properties requires the capability WriteProperty, which is not provided by the context. (Typing[4401])
-  File "/home/example/write-props-bad.hack", line 15, characters 38-39:
-  The local (enclosing) context provides the capability set {}
-
+File "/home/example/write-props-bad.hack", line 16, characters 3-22:
+Writing to object properties in a pure function is not allowed. (Parsing[1002])

--- a/build/extracted-examples/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities/write-props-bad.hack.type-errors.hhvm.expectf
+++ b/build/extracted-examples/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities/write-props-bad.hack.type-errors.hhvm.expectf
@@ -1,0 +1,1 @@
+Fatal error: Writing to object properties in a pure function is not allowed. in %s/write-props-bad.hack.type-errors on line 11

--- a/build/extracted-examples/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities/write-props-bad.hack.type-errors.typechecker.expectf
+++ b/build/extracted-examples/guides/hack/13-contexts-and-capabilities/08-available-contexts-and-capabilities/write-props-bad.hack.type-errors.typechecker.expectf
@@ -1,12 +1,5 @@
-File "%s/write-props-bad.hack", line 11, characters 5-12:
-This object's property is being mutated (used as an lvalue)
-Setting non-mutable object properties requires the capability WriteProperty, which is not provided by the context. (Typing[4401])
-  File "%s/write-props-bad.hack", line 10, characters 31-32:
-  The local (enclosing) context provides the capability set {}
+File "%s/write-props-bad.hack", line 11, characters 5-37:
+Writing to object properties in a pure function is not allowed. (Parsing[1002])
 
-File "%s/write-props-bad.hack", line 16, characters 3-8:
-This object's property is being mutated (used as an lvalue)
-Setting non-mutable object properties requires the capability WriteProperty, which is not provided by the context. (Typing[4401])
-  File "%s/write-props-bad.hack", line 15, characters 38-39:
-  The local (enclosing) context provides the capability set {}
-
+File "%s/write-props-bad.hack", line 16, characters 3-22:
+Writing to object properties in a pure function is not allowed. (Parsing[1002])

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "facebook/xhp-lib": "^4.0",
-        "hhvm": "4.130.*",
+        "hhvm": "4.134.*",
         "usox/hackttp": "~0.5.3",
         "hhvm/hhvm-autoload": "^3.0",
         "hhvm/type-assert": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d817bed156462901d35096c91f69e05e",
+    "content-hash": "be540e87942350967e7a47530e3e9c08",
     "packages": [
         {
             "name": "facebook/definition-finder",
@@ -478,16 +478,16 @@
         },
         {
             "name": "hhvm/hhast",
-            "version": "v4.127.1",
+            "version": "v4.133.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhast.git",
-                "reference": "f6480404bd1c02d4001a7d12580955a58134eb1a"
+                "reference": "c1969515e8bc9ea2d581a3ce3380efd372126059"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/f6480404bd1c02d4001a7d12580955a58134eb1a",
-                "reference": "f6480404bd1c02d4001a7d12580955a58134eb1a",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/c1969515e8bc9ea2d581a3ce3380efd372126059",
+                "reference": "c1969515e8bc9ea2d581a3ce3380efd372126059",
                 "shasum": ""
             },
             "require": {
@@ -514,7 +514,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "4.x-dev",
+                    "dev-main": "4.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -524,9 +525,9 @@
             "description": "A mutable AST library for Hack with linting and code migrations",
             "support": {
                 "issues": "https://github.com/hhvm/hhast/issues",
-                "source": "https://github.com/hhvm/hhast/tree/v4.127.1"
+                "source": "https://github.com/hhvm/hhast/tree/v4.133.0"
             },
-            "time": "2021-09-16T17:58:37+00:00"
+            "time": "2021-10-25T21:13:45+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",
@@ -916,8 +917,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "hhvm": "4.130.*"
+        "hhvm": "4.134.*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/guides/hack/02-source-code-fundamentals/10-comments.md
+++ b/guides/hack/02-source-code-fundamentals/10-comments.md
@@ -3,8 +3,6 @@ Hack has three comment syntaxes.
 ```show-comment-styles.hack no-auto-output
 // A single line comment.
 
-# Also a single line comment.
-
 /* A multi line comment.
  *
  */

--- a/src/build/UpdateTagsCLI.hack
+++ b/src/build/UpdateTagsCLI.hack
@@ -166,7 +166,10 @@ final class UpdateTagsCLI extends CLIBase {
     $this->updateComposerJson($new_major_minor);
 
     await $stdout->writeAllAsync(" - updating Dockerfiles\n");
-    foreach (\glob(LocalConfig::ROOT.'/.deploy/*.Dockerfile') as $path) {
+    $dockerfiles = \glob(LocalConfig::ROOT.'/.deploy/*.Dockerfile');
+    $dockerfiles[] = LocalConfig::ROOT.'/.devcontainer.json';
+
+    foreach ($dockerfiles as $path) {
       \file_get_contents($path)
         |> Str\replace(
           $$,

--- a/src/codegen/PRODUCT_TAGS.php
+++ b/src/codegen/PRODUCT_TAGS.php
@@ -2,12 +2,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<691e439516cbe6e76f7c1b3e52625faa>>
+ * @generated SignedSource<<f8539427089ddebb0e1f1a56b0bb202b>>
  */
 namespace HHVM\UserDocumentation;
 
 const dict<APIProduct, string> PRODUCT_TAGS = dict[
-  APIProduct::HACK => 'HHVM-4.130.0',
+  APIProduct::HACK => 'HHVM-4.134.0',
   APIProduct::HSL => 'v4.108.1',
   APIProduct::HSL_EXPERIMENTAL => 'v4.108.0',
 ];


### PR DESCRIPTION
- Provide more readable error output for expect/expectf/expectre failures on typechecker tests
- Update to 4.134.0
- update composer.lock
- Add a devcontainer
