### PR TITLE
Rework devcontainer to use proxygen server

### DIFF
--- a/.deploy/built-site.Dockerfile
+++ b/.deploy/built-site.Dockerfile
@@ -1,7 +1,6 @@
 # Creates a docker image with a built copy of the site. Not repo-auth.
 # Useful as a scratch/testing area.
 FROM hhvm/hhvm:4.134-latest
-ARG DOCKER_BUILD_ENV=prod
 ENV TZ UTC
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
@@ -10,4 +9,4 @@ ENV LC_ALL en_US.UTF-8
 RUN rm -rf /var/www
 ADD . /var/www
 
-RUN touch /docker_build && cd /var/www && .deploy/init.sh
+RUN cd /var/www && touch /.docker_build && .deploy/init.sh

--- a/.deploy/built-site.Dockerfile
+++ b/.deploy/built-site.Dockerfile
@@ -3,7 +3,6 @@
 FROM hhvm/hhvm:4.134-latest
 ARG DOCKER_BUILD_ENV=prod
 ENV TZ UTC
-ENV DEBIAN_FRONTEND noninteractive
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/.deploy/init.sh
+++ b/.deploy/init.sh
@@ -15,6 +15,10 @@ echo "** Installing apt dependencies"
 apt-get clean
 apt-get update -y
 
+# Some environments (e.g. VSCode containers) will copy the exterior locale
+# settings, which can break things if the current locale isn't usable in the
+# container; using the `C` locale makes sure that the `locales` package
+# post-install succeeds.
 LC_ALL=C apt-get install -y ruby php-cli zip unzip locales
 
 echo "** Updating locales"

--- a/.deploy/init.sh
+++ b/.deploy/init.sh
@@ -7,13 +7,15 @@ if [ ! -e /docker_build ]; then
   exit 1
 fi
 
+export DEBIAN_FRONTEND=noninteractive
+
 echo "** Installing apt dependencies"
 # This is done by the dockerfile, but the intermediate issue can be cached, so do
 # it again here.
 apt-get clean
 apt-get update -y
 
-apt-get install -y ruby php-cli zip unzip locales
+LC_ALL=C apt-get install -y ruby php-cli zip unzip locales
 
 echo "** Updating locales"
 locale-gen en_US.UTF-8

--- a/.deploy/init.sh
+++ b/.deploy/init.sh
@@ -2,35 +2,17 @@
 
 set -ex
 
-if [ ! -e /docker_build ]; then
+if ! [ -e /.docker_build ]; then
   echo "This script should only be ran from a Dockerfile"
   exit 1
 fi
 
-export DEBIAN_FRONTEND=noninteractive
-
-echo "** Installing apt dependencies"
-# This is done by the dockerfile, but the intermediate issue can be cached, so do
-# it again here.
-apt-get clean
-apt-get update -y
-
-# Some environments (e.g. VSCode containers) will copy the exterior locale
-# settings, which can break things if the current locale isn't usable in the
-# container; using the `C` locale makes sure that the `locales` package
-# post-install succeeds.
-LC_ALL=C apt-get install -y ruby php-cli zip unzip locales
-
-echo "** Updating locales"
-locale-gen en_US.UTF-8
-
-echo "** Installing composer"
-mkdir /opt/composer
-wget -qO /dev/stdout https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-if [ ! -x /usr/local/bin/composer ]; then
-  echo "Failed to install composer"
+if ! [ -x .deploy/system-init.sh ]; then
+  echo "Run from the root directory of the source tree."
   exit 1
 fi
+
+.deploy/system-init.sh
 
 echo "** Installing Hack dependencies"
 composer install

--- a/.deploy/system-init.sh
+++ b/.deploy/system-init.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -ex
+
+if ! [ -e /.docker_build ]; then
+  echo "This script should only be ran from a Dockerfile"
+  exit 1
+fi
+
+STAMP_FILE=/.hack_docs_system_init.stamp
+if [ -e "$STAMP_FILE" ]; then
+  exit
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "** Installing apt dependencies"
+# This is done by the dockerfile, but the intermediate issue can be cached, so do
+# it again here.
+apt-get clean
+apt-get update -y
+
+# Some environments (e.g. VSCode containers) will copy the exterior locale
+# settings, which can break things if the current locale isn't usable in the
+# container; using the `C` locale makes sure that the `locales` package
+# post-install succeeds.
+LC_ALL=C apt-get install -y ruby php-cli zip unzip locales
+
+echo "** Updating locales"
+locale-gen en_US.UTF-8
+
+echo "** Installing composer"
+wget -qO /dev/stdout https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+if [ ! -x /usr/local/bin/composer ]; then
+  echo "Failed to install composer"
+  exit 1
+fi
+
+touch "$STAMP_FILE"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM hhvm/hhvm-proxygen:4.134-latest
+
+ARG WORKSPACE
+
+RUN rm -rf /var/www; ln -s ${WORKSPACE} /var/www
+RUN ln -sf /var/www/hhvm.dev.ini /etc/hhvm/site.ini
+RUN touch /docker_build

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,4 +4,6 @@ ARG WORKSPACE
 
 RUN rm -rf /var/www; ln -s ${WORKSPACE} /var/www
 RUN ln -sf /var/www/hhvm.dev.ini /etc/hhvm/site.ini
-RUN touch /docker_build
+
+ADD .deploy/system-init.sh /var/tmp/system-init.sh
+RUN touch /.docker_build && /var/tmp/system-init.sh && rm /var/tmp/system-init.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,16 @@
   "runArgs": [
     "--init"
   ],
-  "image": "hhvm/hhvm:4.134-latest",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "WORKSPACE": "${containerWorkspaceFolder}"
+    }
+  },
+  "runArgs": [
+    "--env", "LC_ALL=C"
+  ],
+  "overrideCommand": false,
 
   // Set *default* container specific settings.json values on container create.
   "settings": {
@@ -19,12 +28,7 @@
 	"terminal.integrated.defaultProfile.linux": "bash"
 },
 
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-	"pranayagarwal.vscode-hack",
-],
-
-  "postCreateCommand": "touch /docker_build; .deploy/init.sh",
-  "postStartCommand": "cd public; hhvm -m server -p 8080 -vServer.AllowRunAsRoot=1 -c ../hhvm.dev.ini",
-  "forwardPorts": [	8080 ]
+  "extensions": [	"pranayagarwal.vscode-hack" ],
+  "forwardPorts": [	80 ],
+  "postCreateCommand": ".deploy/init.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
     "dockerfile": "Dockerfile",
     "args": {
       "WORKSPACE": "${containerWorkspaceFolder}"
-    }
+    },
+    "context": ".."
   },
   "runArgs": [
     "--env", "LC_ALL=C"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,3 @@
-// For format details, see https://aka.ms/devcontainer.json.
 {
   "name": "docs.hhvm.com",
   "runArgs": [
@@ -17,18 +16,18 @@
 
   // Set *default* container specific settings.json values on container create.
   "settings": {
-	"terminal.integrated.profiles.linux": {
-		"bash": {
-			"path": "/bin/bash",
-			"args": [
-				"--login"
-			]
-		}
-	},
-	"terminal.integrated.defaultProfile.linux": "bash"
-},
+    "terminal.integrated.profiles.linux": {
+      "bash": {
+        "path": "/bin/bash",
+        "args": [
+          "--login"
+        ]
+      }
+    },
+    "terminal.integrated.defaultProfile.linux": "bash"
+  },
 
-  "extensions": [	"pranayagarwal.vscode-hack" ],
-  "forwardPorts": [	80 ],
+  "extensions": [ "pranayagarwal.vscode-hack" ],
+  "forwardPorts": [ 80 ],
   "postCreateCommand": ".deploy/init.sh"
 }

--- a/src/build/UpdateTagsCLI.hack
+++ b/src/build/UpdateTagsCLI.hack
@@ -167,7 +167,7 @@ final class UpdateTagsCLI extends CLIBase {
 
     await $stdout->writeAllAsync(" - updating Dockerfiles\n");
     $dockerfiles = \glob(LocalConfig::ROOT.'/.deploy/*.Dockerfile');
-    $dockerfiles[] = LocalConfig::ROOT.'/.devcontainer.json';
+    $dockerfiles[] = LocalConfig::ROOT.'/.devcontainer/Dockerfile';
 
     foreach ($dockerfiles as $path) {
       \file_get_contents($path)


### PR DESCRIPTION
This means that `hhvm` is the actual docker command; the bad news is that if
hhvm crashes, the container goes down.

I'm doing this anyway as there doesn't appear to be support in
devcontainer.json for a separate long-running command - only via docker
compose, which:

- feels like overkill
- appears not to support devcontainer variables like
  containerWorkspaceFolder; this means that it can't work with GitHub
  codespaces, as the `workspaceMount` devcontainer.json option is not
  supported on codespaces

The lack of support for `workspaceMount` is also why there's the fun
messing around with symlinking /var/www and configuration files.
