### PR TITLE
link clearing capabilities to memoize attributes

### DIFF
--- a/guides/hack/20-attributes/07-predefined-attributes.md
+++ b/guides/hack/20-attributes/07-predefined-attributes.md
@@ -221,7 +221,9 @@ The types of the parameters are restricted to the following: `null`, `bool`, `in
 
 The interface type `IMemoizeParam` assists with memoizing objects passed to async functions.
 
-To clear the cache and avoid potential memory leaks, use `HH\clear_static_memoization`.
+You can clear the cache with `HH\clear_static_memoization`. This should only be used **in tests** where:
+- the component being tested is meant to be immutable/idempotent for the entire request
+- the test needs to cover multiple initial states, where only one would truly be reachable in a single request
 
 ### Exceptions
 
@@ -316,7 +318,9 @@ async function main(): Awaitable<void> {
 
 This is like [<<__Memoize>>](#__memoize), but the cache has Late Static Binding. Each subclass has its own memoize cache.
 
-Similarly, you can clear the cache and avoid potential memory leaks with `HH\clear_lsb_memoization`.
+You can clear the cache with `HH\clear_lsb_memoization`. This should only be used **in tests** where:
+- the component being tested is meant to be immutable/idempotent for the entire request
+- the test needs to cover multiple initial states, where only one would truly be reachable in a single request
 
 ## __MockClass
 

--- a/guides/hack/20-attributes/07-predefined-attributes.md
+++ b/guides/hack/20-attributes/07-predefined-attributes.md
@@ -221,6 +221,8 @@ The types of the parameters are restricted to the following: `null`, `bool`, `in
 
 The interface type `IMemoizeParam` assists with memoizing objects passed to async functions.
 
+To clear the cache and avoid potential memory leaks, use `HH\clear_static_memoization`.
+
 ### Exceptions
 
 Thrown exceptions are not memoized, showing by the increasing counter in this
@@ -313,6 +315,8 @@ async function main(): Awaitable<void> {
 ## __MemoizeLSB
 
 This is like [<<__Memoize>>](#__memoize), but the cache has Late Static Binding. Each subclass has its own memoize cache.
+
+Similarly, you can clear the cache and avoid potential memory leaks with `HH\clear_lsb_memoization`.
 
 ## __MockClass
 


### PR DESCRIPTION
* @ryangreenberg had a great idea to link the HH clearing functions for `__Memoize` and `__MemoizeLSB` on the [attributes page](https://docs.hhvm.com/hack/attributes/predefined-attributes).
* Fixes #674