### PR TITLE
Re-add the fbonly messages to the HSL pages

### DIFF
--- a/src/hh-apidoc-extensions/PageSections/FrontMatter.php
+++ b/src/hh-apidoc-extensions/PageSections/FrontMatter.php
@@ -42,21 +42,20 @@ final class FrontMatter extends PageSection {
       $data['class'] = $def->getName();
     }
 
-    $builtin = C\any(
-      $data['sources'],
-      $s ==> Str\starts_with($s, 'api-sources/hhvm/'),
-    );
-    if ($builtin) {
-      return $data;
-    }
+    $top_level_def = $class ?? $def;
 
     if (
-      C\any($data['sources'], $s ==> Str\starts_with($s, 'api-sources/hsl/'))
+      (
+        $top_level_def->getNamespaceName() === "HH\\Lib" ||
+        Str\starts_with($top_level_def->getNamespaceName(), "HH\\Lib\\")
+      ) &&
+      !C\any($data['sources'], $s ==> Str\starts_with($s, 'api-sources/hsl-experimental'))
     ) {
-      $data['lib'] = shape(
-        'name' => 'the Hack Standard Library',
-        'github' => 'hhvm/hsl',
-        'composer' => 'hhvm/hsl',
+      $data['fbonly messages'] ??= vec[];
+      $data['fbonly messages'][] = Str\format(
+        '%s is available as `%s` in the www repository.',
+        $class is nonnull ? 'The containing class' : 'This',
+        Str\strip_prefix($top_level_def->getName(), 'HH\\Lib\\'),
       );
     } else if (
       C\any(
@@ -70,6 +69,7 @@ final class FrontMatter extends PageSection {
         'composer' => 'hhvm/hsl-experimental',
       );
     }
+
 
     return $data;
   }

--- a/tests/APIPagesTest.php
+++ b/tests/APIPagesTest.php
@@ -221,4 +221,23 @@ class APIPagesTest extends \Facebook\HackTest\HackTest {
     expect(Str\contains($body, '<a href="#guides">'))
       ->toBeTrue('Missing guide links at %s.', $url);
   }
+
+  public async function testMessagesForFBWWW(): Awaitable<void> {
+    // Not HSL
+    list($_, $body) = await PageLoader::getPageAsync('/hack/reference/class/HH.AsyncGenerator/');
+    expect($body)->toNotContainSubstring('www repository');
+
+    // Function
+    list($_, $body) = await PageLoader::getPageAsync('/hsl/reference/function/HH.Lib.C.contains/');
+    expect($body)->toContainSubstring('This is available as <code>C\\contains</code> in the www repository');
+
+    // Class
+    list($_, $body) = await PageLoader::getPageAsync('/hsl/reference/class/HH.Lib.Async.Poll/');
+    expect($body)->toContainSubstring('This is available as <code>Async\\Poll</code> in the www repository');
+
+    // Method
+    // This autolinks because - unlike the previous tests - the target is not the current page.
+    list($_, $body) = await PageLoader::getPageAsync('/hsl/reference/class/HH.Lib.Async.Poll/add/');
+    expect($body)->toMatchRegExp('#The containing class is available as <a [^>]+><code>Async\\\\Poll</code></a> in the www repository#');
+  }
 }


### PR DESCRIPTION
Visible if `<body>` has the `isFbViewer` class instead of
`isNotFbViewer`; the default classes depend on if the source IP is
visible.

Test plan:

- extended unit tests
- no visible change with default CSS classes
- screenshot with `isFbViewer` attached:

<img width="1758" alt="image" src="https://user-images.githubusercontent.com/360927/141846322-68958b6e-5828-40a3-badc-ebb3bc36cb01.png">

