### PR TITLE
re-add asterisk on cheat sheat table

### DIFF
--- a/guides/hack/08-arrays-and-collections/01-introduction.md
+++ b/guides/hack/08-arrays-and-collections/01-introduction.md
@@ -57,7 +57,7 @@ Vec\map(keyset[1, 2], $x ==> $x + 1); // vec[2, 3]
 | Type Refinement                              | `$v is vec<_>`               | `$d is dict<_, _>`             | `$k is keyset<_>`              |
 | `Awaitable` Consolidation                    | `Vec\from_async($v)`         | `Dict\from_async($d)`          | `Keyset\from_async($x)`        |
 
-* `$container` can be a Hack Array or Hack Collection
+\* `$container` can be a Hack Array or Hack Collection
 
 ## Arrays Conversion Cheat sheet
 

--- a/guides/hack/08-arrays-and-collections/01-introduction.md
+++ b/guides/hack/08-arrays-and-collections/01-introduction.md
@@ -57,6 +57,8 @@ Vec\map(keyset[1, 2], $x ==> $x + 1); // vec[2, 3]
 | Type Refinement                              | `$v is vec<_>`               | `$d is dict<_, _>`             | `$k is keyset<_>`              |
 | `Awaitable` Consolidation                    | `Vec\from_async($v)`         | `Dict\from_async($d)`          | `Keyset\from_async($x)`        |
 
+* `$container` can be a Hack Array or Hack Collection
+
 ## Arrays Conversion Cheat sheet
 
 Prefer to use Hack arrays whenever possible. When interfacing with legacy APIs that expect older Containers, it may be easier to convert. Here's how:


### PR DESCRIPTION
* Fixes #1115
* Asterisk explanation was missing in re-add of the arrays cheat sheet

![image](https://user-images.githubusercontent.com/5179225/142503419-3c5084b3-0414-43a7-a2b1-db6b5f901b9c.png)
