### PR TITLE
Add clarity to constants page re: self operator and visibility and type inference

### DIFF
--- a/build/extracted-examples/guides/hack/06-classes/18-constants/auto-color.hack
+++ b/build/extracted-examples/guides/hack/06-classes/18-constants/auto-color.hack
@@ -12,6 +12,6 @@ class Automobile {
 function main(): void {
   \init_docs_autoloader();
 
-  $col = Automobile::DEFAULT_COLOR;
+  $col = Automobile::DEFAULT_COLOR; // or: $col = self::DEFAULT_COLOR;
   echo "\$col = $col\n";
 }

--- a/guides/hack/06-classes/18-constants.md
+++ b/guides/hack/06-classes/18-constants.md
@@ -16,10 +16,10 @@ function main(): void {
 ```
 
 ## Visibility
-Class constants have public visibility and can not be declared as `public`, `protected`, or `private`.
+Class constants are always public, and can not be explicitly declared as `public`, `protected`, or `private`.
 
 ## Selection
-Inside a parent class, use `self::foo` to access a named constant `foo`. Outside a parent class, a class constant's name must be fully qualified with the class and constant name (e.g. `Bar::foo`). For more information, see [scope-resolution operator, `::`](../expressions-and-operators/scope-resolution.md).
+Inside a parent class, use `self::foo` to access a named constant `foo`. Outside a parent class, a class constant's name must be fully qualified with the class and constant name (e.g. `Bar::foo`). For more information, see [scope-resolution operator, `::`](../expressions-and-operators/scope-resolution).
 
 ## Type Inference
 If a class constant's type is omitted, it can be inferred. For example:

--- a/guides/hack/06-classes/18-constants.md
+++ b/guides/hack/06-classes/18-constants.md
@@ -1,5 +1,6 @@
-A class may contain definitions for named constants, which have public visibility.  A class constant belongs to the class
-as a whole, so it is implicitly `static`.  For example:
+A class can contain definitions for named constants. 
+
+Because a class constant belongs to the class as a whole, it is implicitly `static`. For example:
 
 ```auto-color.hack
 class Automobile {
@@ -9,17 +10,24 @@ class Automobile {
 
 <<__EntryPoint>>
 function main(): void {
-  $col = Automobile::DEFAULT_COLOR;
+  $col = Automobile::DEFAULT_COLOR; // or: $col = self::DEFAULT_COLOR;
   echo "\$col = $col\n";
 }
 ```
 
-If a class constant's type is omitted, it is inferred from the initializer, which must be present. In this case, that type is `string`.
+## Visibility
+Class constants have public visibility and can not be declared as `public`, `protected`, or `private`.
 
-As we can see, outside its parent class, a class constant's name must be qualified by the
-[scope-resolution operator, `::`](../expressions-and-operators/scope-resolution.md); after all, multiple classes might define
-constants by the same (unrelated) name.
+## Selection
+Inside a parent class, use `self::foo` to access a named constant `foo`. Outside a parent class, a class constant's name must be fully qualified with the class and constant name (e.g. `Bar::foo`). For more information, see [scope-resolution operator, `::`](../expressions-and-operators/scope-resolution.md).
 
-Note that for some types&mdash;the legacy container types `Vector`, `Map`, `Set`, et al., and closures&mdash;there is *no* way to write an initializer that
-is considered to be a compile-time constant. Therefore, a class constant cannot have such a type. However, the types `array`, `vec`, `dict`, and
-`set`, can be used *provided* all their subinitializers are constant expressions.
+## Type Inference
+If a class constant's type is omitted, it can be inferred. For example:
+* the inferred type of `const DEFAULT_COLOR = "white"` is `string`, 
+* the inferred type of `const DEFAULT_VALUE = 42` is `int`.
+* the inferred type of `const DEFAULT_FOODS = vec["apple", "orange", "banana"]` is `vec`.
+
+## Limitations
+Constants can not be assigned to legacy container types like `Vector`, `Map`, `Set`, et al., and closures. 
+
+Instead, create constants with equivalent types like `array`, `vec`, `dict`, and `set`. When using these types, all subinitializers must resolve to constant expressions.

--- a/guides/hack/06-classes/18-constants.md
+++ b/guides/hack/06-classes/18-constants.md
@@ -19,7 +19,7 @@ function main(): void {
 Class constants are always public, and can not be explicitly declared as `public`, `protected`, or `private`.
 
 ## Selection
-Inside a parent class, use `self::foo` to access a named constant `foo`. Outside a parent class, a class constant's name must be fully qualified with the class and constant name (e.g. `Bar::foo`). For more information, see [scope-resolution operator, `::`](../expressions-and-operators/scope-resolution).
+Inside a parent class, use `self::foo` to access a named constant `foo`. Outside a parent class, a class constant's name must be fully qualified with the class and constant name (e.g. `Bar::foo`). For more information, see [scope-resolution operator, `::`](/hack/expressions-and-operators/scope-resolution).
 
 ## Type Inference
 If a class constant's type is omitted, it can be inferred. For example:


### PR DESCRIPTION
* Add information on self operator
* Rewrite for clarity for areas like type inference and visibility modifiers

![image](https://user-images.githubusercontent.com/5179225/143090671-ef27ffb7-e46e-4d8c-ac51-bdad4f9c98a7.png)

![image](https://user-images.githubusercontent.com/5179225/143090762-57c53bec-bbd1-47d4-9ff1-02d2d4703fc9.png)
