### PR TITLE
Remove external mention of the hsl

### DIFF
--- a/guides/hack/01-getting-started/03-starting-a-real-project.md
+++ b/guides/hack/01-getting-started/03-starting-a-real-project.md
@@ -1,7 +1,7 @@
 ## Starting A Real Project
 
 Real projects generally aren't a single file in isolation; they tend to have
-dependencies such as the [Hack Standard Library], and various optional tools.
+dependencies such as the [TypeAssert](https://github.com/hhvm/type-assert), and various optional tools.
 
 A good starting point is to:
 - [install Composer]


### PR DESCRIPTION
The hsl is built-in. Let's use TypeAssert as an example instead.