### PR TITLE
clarify use of `#` and `#!` in comments guide

### DIFF
--- a/guides/hack/02-source-code-fundamentals/10-comments.md
+++ b/guides/hack/02-source-code-fundamentals/10-comments.md
@@ -29,4 +29,3 @@ A number of special comments are recognized; they are:
 * `// strict` and `// partial` in [headers](/hack/source-code-fundamentals/program-structure)
 * `/* HH_FIXME[1234] */` or `/* HH_IGNORE_ERROR[1234] */`, which
   suppresses typechecker error reporting for error 1234.
-* `#!` in `#!/path/to/executable` (e.g. `/usr/bin/hhvm`), which is the shebang line (interpreter directive).

--- a/guides/hack/02-source-code-fundamentals/10-comments.md
+++ b/guides/hack/02-source-code-fundamentals/10-comments.md
@@ -16,14 +16,17 @@ Hack has three comment syntaxes.
 function foo(): void {}
 ```
 
-Multi line comments start with `/*` and end with `*/`. Comments
+Multi-line comments start with `/*` and end with `*/`. Comments
 starting `/**` are also used for documentation.
 
-Single-line comments start with `//` or `#`, and end with a newline.
+Single-line comments start with `//` and end with a newline. 
+
+`#` is not a valid comment character, as it is used to represent an [Enum Class Label](/hack/built-in-types/enum-class-label).
 
 A number of special comments are recognized; they are:
 
-* `// FALLTHROUGH` in [switch statements](../statements/switch.md)
-* `// strict` and `// partial` in [headers](program-structure.md)
+* `// FALLTHROUGH` in [switch statements](/hack/statements/switch)
+* `// strict` and `// partial` in [headers](/hack/source-code-fundamentals/program-structure)
 * `/* HH_FIXME[1234] */` or `/* HH_IGNORE_ERROR[1234] */`, which
   suppresses typechecker error reporting for error 1234.
+* `#!` in `#!/path/to/executable` (e.g. `/usr/bin/hhvm`), which is the shebang line (interpreter directive).


### PR DESCRIPTION
* Remove `#` as a valid comment character
* Add link to Enum Class Label docs
* Add information on `#!` to special characters
* Use full paths for hrefs

![image](https://user-images.githubusercontent.com/5179225/148431621-bd4fa1f4-b318-4330-8e6f-bb43f1e66927.png)
