### PR TITLE
Use separate CMake build directory

### DIFF
--- a/guides/hhvm/01-installation/07-building-from-source.md
+++ b/guides/hhvm/01-installation/07-building-from-source.md
@@ -72,7 +72,9 @@ git submodule update --init --recursive
 This will take a *long* time.
 
 ```
-cmake -DMYSQL_UNIX_SOCK_ADDR=/var/run/mysqld/mysqld.sock .
+mkdir build
+cd build
+cmake -DMYSQL_UNIX_SOCK_ADDR=/var/run/mysqld/mysqld.sock ..
 make -j [number_of_processor_cores] # eg. make -j 4
 sudo make install
 ```


### PR DESCRIPTION
`cmake .` would mess up the git source tree. This PR instead asks the developer to create a new directory `build`, which would be ignored by https://github.com/facebook/hhvm/blob/master/.gitignore