### PR TITLE
Prevent hh-apidoc from being upgraded to an incompatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "hhvm/hsl": "^4.25",
         "hhvm/hsl-experimental": "^4.93",
         "facebook/fbmarkdown": "^1.0",
-        "facebook/hh-apidoc": ">=0.6 <1.0"
+        "facebook/hh-apidoc": ">=0.6 <0.8"
     },
     "require-dev": {
         "hhvm/hhast": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19331bd595e369bcd05b8e899ebb08af",
+    "content-hash": "9e79c120c79975e840f558d7045b83ec",
     "packages": [
         {
             "name": "facebook/definition-finder",


### PR DESCRIPTION
According to https://github.com/hhvm/hh-apidoc/releases/tag/v0.8.0 , hh-apidoc is not backward compatible with 0.6.0. 