### PR TITLE
[draft] initial UI update for feedback

### DIFF
--- a/sass/core.scss
+++ b/sass/core.scss
@@ -15,6 +15,7 @@
 @import "innerContent";
 @import "tables";
 @import "pagination";
+@import "feedback";
 @import "search";
 @import "survey";
 @import "buttons";

--- a/sass/feedback.scss
+++ b/sass/feedback.scss
@@ -1,0 +1,50 @@
+.feedbackForm {
+  line-height: normal;
+  padding-top: 20px;
+  font-size: 15px;
+  font-weight: bold;
+  text-align: center;
+
+  .fa-thumbs-up {
+    vertical-align: text-top;
+  }
+  
+  .fa-thumbs-down {
+    vertical-align: text-bottom;
+  }
+
+  #form-basic {
+    display: block;
+  }
+
+  #form-yes {
+    display: none;
+  }
+  
+  #form-no {
+    display: none;
+  }
+
+  &.feedbackPromptOff {
+    #form-basic {
+      display: none;
+    }
+  }
+
+  &.goodFeedbackOn {
+    #form-yes {
+      display: block;
+    }
+  }
+
+  &.badFeedbackOn {
+    #form-no {
+      display: block;
+    }
+  }
+}
+
+.feedbackForm i {
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+}

--- a/src/site/controllers/GuidePageController.php
+++ b/src/site/controllers/GuidePageController.php
@@ -98,6 +98,7 @@ final class GuidePageController extends WebPageController {
       <div class="guidePageWrapper">
         {$this->getInnerContent()}
         {$this->getPaginationLinks()}
+        {$this->getFeedbackForm()}
       </div>;
   }
 
@@ -228,6 +229,11 @@ final class GuidePageController extends WebPageController {
       $adj_guide = tuple($guide, $data);
     }
     return $adj_guide;
+  }
+
+  protected function getFeedbackForm(): x\node {
+    $feedback = <ui:feedback/>;
+    return $feedback;
   }
 
   <<__Override>>

--- a/src/site/controllers/NonRoutableWebPageController.php
+++ b/src/site/controllers/NonRoutableWebPageController.php
@@ -307,7 +307,7 @@ EOF;
               issueBody={$this->getGithubIssueBody()}
               controller={static::class}>
               <ui:glyph icon={UIGlyphIcon::BUG} />
-              report a problem or make a suggestion
+              See Something Wrong? File an Issue
             </github_issue_link>
           </div>
           <search_bar
@@ -332,28 +332,10 @@ EOF;
     parent::__construct($parameters, $request);
   }
 
-  private function getFeedbackFooter(): x\node {
-    return
-      <div class="footerPanel footerPanelFullWidth">
-        <h2>See something wrong?</h2>
-        <ui:button className="gitHubIssueButton" glyph={UIGlyphIcon::BUG}>
-          <span>
-            <github_issue_link
-              issueTitle={$this->getGithubIssueTitle()}
-              issueBody={$this->getGithubIssueBody()}
-              controller={static::class}>
-              Report a problem or make a suggestion.
-            </github_issue_link>
-          </span>
-        </ui:button>
-      </div>;
-  }
-
   private function getFooter(): footer {
     return
       <footer class="footerWrapper">
         <div class="mainWrapper">
-          {$this->getFeedbackFooter()}
           <div class="footerPanel">
             <h2>Hack</h2>
             <ul>

--- a/src/site/xhp/ui-feedback.php
+++ b/src/site/xhp/ui-feedback.php
@@ -1,0 +1,112 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+namespace HHVM\UserDocumentation\ui;
+
+use namespace Facebook\XHP\Core as x;
+use type Facebook\XHP\HTML\{div, i, script};
+use type HHVM\UserDocumentation\{
+  github_issue_link,
+};
+
+final xhp class feedback extends x\element {
+
+  <<__Override>>
+  protected async function renderAsync(): Awaitable<x\node> {
+    $thumbs_up =
+      <i class="fa fa-solid fa-thumbs-up fa-lg"></i>;
+
+    $thumbs_down =
+      <i class="fa fa-solid fa-thumbs-down fa-lg"></i>;
+
+    $feedback =
+      <div id="form-basic">Was This Page Useful?
+        {$thumbs_up}
+        {$thumbs_down}
+      </div>;
+
+    $good_feedback =
+      <div id="form-yes">Thank You!</div>;
+
+    $bad_feedback =
+      <div id="form-no">Thank You. Please <github_issue_link issueTitle={$this->getGithubIssueTitle()} issueBody={$this->getGithubIssueBody()}>File an Issue</github_issue_link> to help future readers!</div>;
+
+    $container = (
+      <div class="feedbackForm">
+        {$feedback}
+        {$good_feedback}
+        {$bad_feedback}
+      </div>
+    );
+
+    $container->appendChild(varray[
+      $this->toggleGoodFeedbackScript($thumbs_up, $container),
+      $this->toggleBadFeedbackScript($thumbs_down, $container),
+    ]);
+
+    return $container;
+  }
+
+  private function toggleGoodFeedbackScript(i $button, div $container): script {
+    $button_id = \json_encode($button->getID());
+    $container_id = \json_encode($container->getID());
+    return (
+      <script language="javascript">
+        var toggleButton = document.getElementById({$button_id});
+        toggleButton.addEventListener(
+        'click',
+        function() {"{"}
+        var toggleContainer = document.getElementById({$container_id});
+        toggleContainer.classList.toggle('feedbackPromptOff');
+        toggleContainer.classList.toggle('goodFeedbackOn');
+        {"}"}
+        );
+      </script>
+    );
+  }
+
+  private function toggleBadFeedbackScript(i $button, div $container): script {
+    $button_id = \json_encode($button->getID());
+    $container_id = \json_encode($container->getID());
+    return (
+      <script language="javascript">
+        var toggleButton = document.getElementById({$button_id});
+        toggleButton.addEventListener(
+        'click',
+        function() {"{"}
+        var toggleContainer = document.getElementById({$container_id});
+        toggleContainer.classList.toggle('feedbackPromptOff');
+        toggleContainer.classList.toggle('badFeedbackOn');
+        {"}"}
+        );
+      </script>
+    );
+  }
+
+  protected function getGithubIssueTitle(): ?string {
+      return null;
+  }
+
+  protected function getGithubIssueBody(): string {
+    return <<<EOF
+Please complete the information below:
+
+# Where is the problem?
+
+- e.g. "The section describing how widgets work"
+
+# What is the problem?
+
+- e.g. "It doesn't explain that widgets are singletons"
+EOF;
+  }
+
+}


### PR DESCRIPTION
Proposal for UI Feedback widget for page quality.

* Added XHP component for a new feedback form with font awesome icons and new CSS
* Updated text in header for requesting filling out bugs / issues 
* Removed footer issue component. Felt like too much was going on with the new Feedback component.
* Added GH Issue embed for negative feedback
* Only applied to Guides pages
* TODO: Receive Event data in GA

RFC:
* Any opinions on "Was This Page Useful?" compared to ... "Was this Page Helpful?" or... "Did this Page Answer Your Question?" ... or {other suggestion}?
* Apply to Reference pages too?
* Thoughts on design / placement?

## New Feedback Component
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5179225/155076871-f23e37a8-94be-4af1-bf34-d379a9e03a63.png">

# Good Feedback Flow
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5179225/155076917-54646844-4ce9-48f1-aaab-39984b2a9e9e.png">

# Bad Feedback Flow
<img width="1679" alt="image" src="https://user-images.githubusercontent.com/5179225/155076946-aaf926ae-22a8-413f-b090-c9381705006e.png">

# Feedback Footer Removed
<img width="1678" alt="image" src="https://user-images.githubusercontent.com/5179225/155077704-a4ded606-a1bd-4b7a-9aeb-87e81fc6fb0a.png">




