### PR TITLE
enclose main function in an async context

### DIFF
--- a/build/extracted-examples/guides/hack/21-XHP/01-introduction/tag-matching-validation.hack.type-errors
+++ b/build/extracted-examples/guides/hack/21-XHP/01-introduction/tag-matching-validation.hack.type-errors
@@ -21,7 +21,7 @@ async function intro_examples_tag_matching_validation_using_xhp(
 }
 
 <<__EntryPoint>>
-function intro_examples_tag_matching_validation_run(): void {
+async function intro_examples_tag_matching_validation_run(): Awaitable<void> {
   intro_examples_tag_matching_validation_using_string();
   await intro_examples_tag_matching_validation_using_xhp();
 }

--- a/guides/hack/21-XHP/01-introduction.md
+++ b/guides/hack/21-XHP/01-introduction.md
@@ -126,7 +126,7 @@ async function intro_examples_tag_matching_validation_using_xhp(
 }
 
 <<__EntryPoint>>
-function intro_examples_tag_matching_validation_run(): void {
+async function intro_examples_tag_matching_validation_run(): Awaitable<void> {
   intro_examples_tag_matching_validation_using_string();
   await intro_examples_tag_matching_validation_using_xhp();
 }


### PR DESCRIPTION
If I understand right, should be an async function. 

Taken from: https://docs.hhvm.com/hack/XHP/introduction#runtime-validation

## Before
```
<<__EntryPoint>>
function intro_examples_tag_matching_validation_run(): void {
  intro_examples_tag_matching_validation_using_string();
  await intro_examples_tag_matching_validation_using_xhp();
}
```
## After
```
<<__EntryPoint>>
async function intro_examples_tag_matching_validation_run(): Awaitable<void> {
  intro_examples_tag_matching_validation_using_string();
  await intro_examples_tag_matching_validation_using_xhp();
}
```