### PR TITLE
Don't expect Cannot use unstable feature: `abstract_enum_class`

### DIFF
--- a/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassIntro.Abstract.hack.hhvm.expectf
+++ b/build/extracted-examples/guides/hack/11-built-in-types/35-enum-class/EnumClassIntro.Abstract.hack.hhvm.expectf
@@ -1,2 +1,0 @@
-
-Fatal error: Cannot use unstable feature: `abstract_enum_class` in %s/EnumClassIntro.Abstract.hack on line 10


### PR DESCRIPTION
This expect does not match the behavior of 4.154.
This feature is not unstable anymore.
The expected output is an empty file.