### PR TITLE
Improve sidebar user experience

### DIFF
--- a/sass/navigation.scss
+++ b/sass/navigation.scss
@@ -27,6 +27,14 @@
       }
     }
 
+    .navGroup:after {
+      content: '';
+      display: block;
+      margin: 0 auto;
+      width: 80%;
+      border-bottom: 1px solid #DADADA;
+    }
+
     li {
       a {
         color: $lightgrey;
@@ -54,6 +62,7 @@
 
   .subList {
     margin-bottom: 20px;
+    padding-left: 20px;
     display: none;
 
     .subListItem {

--- a/sass/navigation.scss
+++ b/sass/navigation.scss
@@ -27,6 +27,7 @@
       }
     }
 
+    // horizontal line functionality in resized pseudo-element
     .navGroup:after {
       content: '';
       display: block;
@@ -34,6 +35,8 @@
       width: 80%;
       border-bottom: 1px solid #DADADA;
     }
+
+    .navGroup:hover:after { content: none; }
 
     li {
       a {


### PR DESCRIPTION
This PR affects the sidebar in these ways:
* indents subpages
* adds line separators between section topics

## Current
<img width="1895" alt="image" src="https://user-images.githubusercontent.com/5179225/160945201-b55c62fe-1d84-4ea2-8306-291c900dab22.png">

## Proposed
<img width="1893" alt="image" src="https://user-images.githubusercontent.com/5179225/160945284-2ec240c3-3da0-478e-b4a0-6a8e82500dd6.png">

## Issues
There is a line above the background-color when an element is :hover, which on close examination looks a bit weird, because I can't select the previous sibling to remove the :after pseudo-element. 

<img width="1673" alt="image" src="https://user-images.githubusercontent.com/5179225/161154008-4a97814c-77ef-4975-ad2f-0aaca9481215.png">
