### PR TITLE
Add underscores to numeric literals

### DIFF
--- a/guides/hack/02-source-code-fundamentals/19-literals.md
+++ b/guides/hack/02-source-code-fundamentals/19-literals.md
@@ -19,6 +19,15 @@ $count = 10      // decimal 10
 0XAf << 012      // hexadecimal Af and octal 12
 ```
 
+Integer literals can also contain underscores as digit separators. They function only as visual aids, they have no
+actual meaning. For example:
+
+```Hack
+$amount = 394_493_392 // completely equivalent to 394493392
+$address = 0x49AD_DF30;
+$permission = 012_212_001;
+```
+
 ## Floating-Point Literals
 
 Floating-point literals typically have an integer part, a decimal point, and a fractional part. They may also have an
@@ -29,6 +38,12 @@ exponent part. They are written using decimal digits.  The type of a floating-po
 ```
 
 The predefined constants `INF` and `NAN` provide access to the floating- point values for infinity and Not-a-Number, respectively.
+
+Floating-point literals may also contain underscores as digit separators in the integer part, the fractional part, and the exponent part. For example:
+
+```Hack
+123_456.49_30e-30_30
+```
 
 ## String Literals
 


### PR DESCRIPTION
This adds language to indicate that underscores can be used as visual separators in numeric literals.