### PR TITLE
Add HHVM 4.153 LTS to Release Schedule

### DIFF
--- a/guides/hhvm/01-installation/06-release-schedule.md
+++ b/guides/hhvm/01-installation/06-release-schedule.md
@@ -9,7 +9,7 @@ due at that time is delayed, support is extended.
 
 Here's a table of recent LTS releases as well as *expected* future LTS releases:
 
-| Version |    \*Release Date       |    \*End of Suppport       |
+| Version |    \*Release Date       |    \*End of Support       |
 | ------- | ----------------------- | -------------------------- |
 | [4.153](https://hhvm.com/blog/2022/03/17/hhvm-4.153.html)  | March 17, 2022        | *February 16, 2023*      |
 | [4.128](https://hhvm.com/blog/2021/09/21/hhvm-4.128.html)  | September 21, 2021    | *August 24, 2022*        |

--- a/guides/hhvm/01-installation/06-release-schedule.md
+++ b/guides/hhvm/01-installation/06-release-schedule.md
@@ -11,11 +11,12 @@ Here's a table of recent LTS releases as well as *expected* future LTS releases:
 
 | Version |    \*Release Date       |    \*End of Suppport       |
 | ------- | ----------------------- | -------------------------- |
-| [4.128](https://hhvm.com/blog/2021/09/21/hhvm-4.128.html)  | *September 22nd, 2021*  | *August 24th, 2022*        |
-| [4.102¹](https://hhvm.com/blog/2021/03/23/hhvm-4.102.html) | March 23rd, 2021        | *March 7th, 2022*          |
-| [4.80](https://hhvm.com/blog/2020/10/21/hhvm-4.80.html)    | October 21st, 2020      | *September 22nd, 2021*     | 
-| [4.56](https://hhvm.com/blog/2020/05/04/hhvm-4.56.html)    | May 4th, 2020           | April 5th, 2021            |
-| [4.32](https://hhvm.com/blog/2019/11/19/hhvm-4.32.html)    | November 19th, 2019     | October 21st, 2020         |
+| [4.153](https://hhvm.com/blog/2022/03/17/hhvm-4.153.html)  | March 17, 2022        | *February 16, 2023*      |
+| [4.128](https://hhvm.com/blog/2021/09/21/hhvm-4.128.html)  | September 21, 2021    | *August 24, 2022*        |
+| [4.102¹](https://hhvm.com/blog/2021/03/23/hhvm-4.102.html) | March 23, 2021        | March 17, 2022           |
+| [4.80](https://hhvm.com/blog/2020/10/21/hhvm-4.80.html)    | October 21, 2020      | September 21, 2021       | 
+| [4.56](https://hhvm.com/blog/2020/05/04/hhvm-4.56.html)    | May 4, 2020           | April 5, 2021            |
+| [4.32](https://hhvm.com/blog/2019/11/19/hhvm-4.32.html)    | November 19, 2019     | October 21, 2020         |
 
 
 \* *Dates in italics signify an **expected** date.*


### PR DESCRIPTION
Add 4.153 LTS and update past end of support dates.

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5179225/165628527-8ec5c4b1-87a2-42e1-9ea6-7a7962b9dae9.png">
