### PR TITLE
Note on hack strict for Meta engineers

### DIFF
--- a/guides/hack/02-source-code-fundamentals/04-program-structure.md
+++ b/guides/hack/02-source-code-fundamentals/04-program-structure.md
@@ -32,6 +32,13 @@ have been `run`, `do_it`, or `make_magic`. (What makes `main` the start-up funct
 A file can import another file via [inclusion](script-inclusion.md).
 
 ## Legacy Files
+```yamlmeta
+{
+  "fbonly messages": [
+    "All Hack source code at Meta should use the .php file extension and Hack strict mode (plain <?hh header line)."
+  ]
+}
+```
 
 The `.php` extension is still in use in older Hack code, though not recommended for new code. Hack code using
 this extension *must* start with an optional shebang line (e.g. `#!/usr/bin/env hhvm`), followed by a header line. The header line can be one of the following:


### PR DESCRIPTION
A note on hack strict, from internal feedback.

`Facebook` -> `Meta` refactor at a later date.

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5179225/165637925-324aca50-20bc-48df-bda3-38cf4bc0b935.png">