### PR TITLE
fix typo for HHAST description

### DIFF
--- a/guides/hack/01-getting-started/02-tools.md
+++ b/guides/hack/01-getting-started/02-tools.md
@@ -34,7 +34,7 @@ with PHP.  Composer can be thought of as an equivalent to `npm` or `yarn`.
 
 - `hackfmt` is a CLI code formatter included with HHVM and Hack, and is also
   used by the various editor and IDE integrations
-- [HHAST] is added provides code style linting, and the ability to automatically
+- [HHAST] provides code style linting, and the ability to automatically
   modify code to adapt to some changes in the language or libraries
 - [hacktest] and [fbexpect] are commonly used together for writing unit tests
 


### PR DESCRIPTION
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/6767142/166551897-3452f81e-a900-407c-acab-48acba963e6c.png">

fixed typo for HHAST