### PR TITLE
add link to explanation of namespaces to arrays and collections docs

### DIFF
--- a/guides/hack/08-arrays-and-collections/01-introduction.md
+++ b/guides/hack/08-arrays-and-collections/01-introduction.md
@@ -21,7 +21,9 @@ $d = dict['a' => 1, 'b' => 3];
 
 ## The Hack Standard Library
 There are many helpful functions in the `C`, `Vec`, `Keyset` and `Dict`
-namespaces, which are a part of the [Hack Standard Library](/hsl/reference).
+namespaces, which are a part of the [Hack Standard Library (HSL)](/hsl/reference).
+
+For more information on included HSL namespaces, see [Hack Standard Library: Namespaces](/hack/getting-started/the-hack-standard-library#hsl-namespaces).
 
 ```Hack
 // The C namespace contains generic functions that are relevant to


### PR DESCRIPTION
New link to explanation of namespaces, surfaced from an internal conversation.

<img width="1259" alt="image" src="https://user-images.githubusercontent.com/5179225/168193976-5b4377e2-9020-4825-9f4e-cd2ca9694050.png">
