### PR TITLE
Update HHVM to 4.160

### DIFF
--- a/.deploy/built-site.Dockerfile
+++ b/.deploy/built-site.Dockerfile
@@ -1,6 +1,6 @@
 # Creates a docker image with a built copy of the site. Not repo-auth.
 # Useful as a scratch/testing area.
-FROM hhvm/hhvm:4.154-latest
+FROM hhvm/hhvm:4.160-latest
 ENV TZ UTC
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/.deploy/prod.Dockerfile
+++ b/.deploy/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM hhvm/hhvm-proxygen:4.154-latest
+FROM hhvm/hhvm-proxygen:4.160-latest
 
 ADD hhvm.prod.ini /etc/hhvm/site.ini
 ADD hhvm.hhbc /var/www/hhvm.hhbc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM hhvm/hhvm-proxygen:4.154-latest
+FROM hhvm/hhvm-proxygen:4.160-latest
 
 ARG WORKSPACE
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu ]
-        hhvm: [ '4.154' ]
+        hhvm: [ '4.160' ]
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@v2

--- a/build/extracted-examples/guides/hack/16-readonly/04-explicit-readonly-keywords/readonly_coeffects.hack
+++ b/build/extracted-examples/guides/hack/16-readonly/04-explicit-readonly-keywords/readonly_coeffects.hack
@@ -12,6 +12,6 @@ class Foo {
 function read_static()[read_globals]: void {
   $y = readonly Foo::$bar; // keyword required
 }
-function read_static2()[controlled]: void {
+function read_static2()[leak_safe]: void {
   $y = readonly Foo::$bar; // keyword required
 }

--- a/build/extracted-examples/guides/hack/21-XHP/16-extending/xhp-async.inc.hack
+++ b/build/extracted-examples/guides/hack/21-XHP/16-extending/xhp-async.inc.hack
@@ -8,7 +8,7 @@ use namespace Facebook\XHP\Core as x;
 final xhp class ui_get_status extends x\element {
 
   protected async function renderAsync(): Awaitable<x\node> {
-    $ch = \curl_init('https://status.fb.com/graph-api');
+    $ch = \curl_init('https://metastatus.com/graph-api');
     \curl_setopt($ch, \CURLOPT_USERAGENT, 'hhvm/user-documentation example');
     $status = await \HH\Asio\curl_exec($ch);
     return <x:frag>Status is: {$status}</x:frag>;

--- a/build/extracted-examples/guides/hack/30-silencing-errors/05-error-codes/4324_array_access.hack
+++ b/build/extracted-examples/guides/hack/30-silencing-errors/05-error-codes/4324_array_access.hack
@@ -4,6 +4,6 @@
 namespace HHVM\UserDocumentation\Guides\Hack\SilencingErrors\ErrorCodes\ArrayAccess;
 
 function foo(int $m): void {
-  /* HH_FIXME[4005] Indexing a type that isn't indexable. */
+  /* HH_FIXME[4324] Indexing a type that isn't indexable. */
   $value = $m['foo'];
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "facebook/xhp-lib": "^4.0",
-        "hhvm": "4.154.*",
+        "hhvm": "4.160.*",
         "usox/hackttp": "~0.5.3",
         "hhvm/hhvm-autoload": "^3.0",
         "hhvm/type-assert": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,37 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "705c9881064372e30d0a74baf8cc6d68",
+    "content-hash": "d0d3d92c584516675a6009d6f4d560d2",
     "packages": [
         {
             "name": "facebook/definition-finder",
-            "version": "v2.14.2",
+            "version": "v2.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/definition-finder.git",
-                "reference": "5f7708abaa7973387ddcc71ff00449852465bee4"
+                "reference": "c26866aed73922c3657f5faebb0dfc2d36b519b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/5f7708abaa7973387ddcc71ff00449852465bee4",
-                "reference": "5f7708abaa7973387ddcc71ff00449852465bee4",
+                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/c26866aed73922c3657f5faebb0dfc2d36b519b2",
+                "reference": "c26866aed73922c3657f5faebb0dfc2d36b519b2",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.78",
-                "hhvm/hhast": "^4.21.4",
-                "hhvm/hhvm-autoload": "^2.0|^3.0",
-                "hhvm/hsl": "^4.0",
+                "hhvm": "^4.158",
+                "hhvm/hhast": "^4.158",
                 "hhvm/type-assert": "^3.2|^4.0"
             },
             "require-dev": {
                 "facebook/fbexpect": "^2.6.1",
-                "hhvm/hacktest": "^2.0"
+                "hhvm/hacktest": "^2.0",
+                "hhvm/hhvm-autoload": "^2.0|^3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "2.x-dev",
+                    "dev-main": "2.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -51,9 +51,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hhvm/definition-finder/issues",
-                "source": "https://github.com/hhvm/definition-finder/tree/v2.14.2"
+                "source": "https://github.com/hhvm/definition-finder/tree/v2.16.0"
             },
-            "time": "2021-05-03T19:37:09+00:00"
+            "time": "2022-04-21T18:51:47+00:00"
         },
         {
             "name": "facebook/difflib",
@@ -98,21 +98,20 @@
         },
         {
             "name": "facebook/fbmarkdown",
-            "version": "v1.6.5",
+            "version": "v1.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/fbmarkdown.git",
-                "reference": "012fd9de7ff08cb22367cc7da581b2abc90d88fd"
+                "reference": "306614c26cfcb00425c17c7a20af7831784826b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/fbmarkdown/zipball/012fd9de7ff08cb22367cc7da581b2abc90d88fd",
-                "reference": "012fd9de7ff08cb22367cc7da581b2abc90d88fd",
+                "url": "https://api.github.com/repos/hhvm/fbmarkdown/zipball/306614c26cfcb00425c17c7a20af7831784826b9",
+                "reference": "306614c26cfcb00425c17c7a20af7831784826b9",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^4.25",
-                "hhvm/hsl": "^4.0",
+                "hhvm": "^4.128",
                 "hhvm/type-assert": "^3.1|^4.0"
             },
             "require-dev": {
@@ -124,7 +123,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "1.x-dev",
+                    "dev-main": "1.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -140,9 +140,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hhvm/fbmarkdown/issues",
-                "source": "https://github.com/hhvm/fbmarkdown/tree/v1.6.5"
+                "source": "https://github.com/hhvm/fbmarkdown/tree/v1.6.6"
             },
-            "time": "2020-12-21T22:50:34+00:00"
+            "time": "2022-05-06T22:33:19+00:00"
         },
         {
             "name": "facebook/hack-codegen",
@@ -482,22 +482,22 @@
         },
         {
             "name": "hhvm/hhast",
-            "version": "v4.139.4",
+            "version": "v4.158.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhast.git",
-                "reference": "cade7dc28053b2731cfc0b54de8773771e4c04c6"
+                "reference": "65d54577488abe021142ca9caf87e5290b7d609e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/cade7dc28053b2731cfc0b54de8773771e4c04c6",
-                "reference": "cade7dc28053b2731cfc0b54de8773771e4c04c6",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/65d54577488abe021142ca9caf87e5290b7d609e",
+                "reference": "65d54577488abe021142ca9caf87e5290b7d609e",
                 "shasum": ""
             },
             "require": {
                 "facebook/difflib": "^1.0.0",
                 "facebook/hh-clilib": "^2.5.0rc1",
-                "hhvm": "^4.128",
+                "hhvm": "^4.157",
                 "hhvm/hhvm-autoload": "^2.0.4|^3.0",
                 "hhvm/hsl": "^4.25",
                 "hhvm/hsl-experimental": "^4.58.0rc1",
@@ -529,9 +529,9 @@
             "description": "A mutable AST library for Hack with linting and code migrations",
             "support": {
                 "issues": "https://github.com/hhvm/hhast/issues",
-                "source": "https://github.com/hhvm/hhast/tree/v4.139.4"
+                "source": "https://github.com/hhvm/hhast/tree/v4.158.3"
             },
-            "time": "2022-03-02T19:16:49+00:00"
+            "time": "2022-05-05T22:14:49+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",
@@ -923,8 +923,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "hhvm": "4.154.*"
+        "hhvm": "4.160.*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/guides/hack/16-readonly/04-explicit-readonly-keywords.md
+++ b/guides/hack/16-readonly/04-explicit-readonly-keywords.md
@@ -33,7 +33,7 @@ function test(Foo $f): void {
 ```
 
 ## Interactions with [Coeffects](https://docs.hhvm.com/hack/contexts-and-capabilities/available-contexts-and-capabilities)
-If your function has the `ReadGlobals` capability but not the `AccessGlobals` capability (i.e. is marked `read_globals` or `controlled`), it can only access class static variables if they are wrapped in a readonly expression:
+If your function has the `ReadGlobals` capability but not the `AccessGlobals` capability (i.e. is marked `read_globals` or `leak_safe`), it can only access class static variables if they are wrapped in a readonly expression:
 
 ``` Hack readonly_coeffects.hack
 <<file:__EnableUnstableFeatures("readonly")>> 
@@ -45,7 +45,7 @@ class Foo {
 function read_static()[read_globals]: void {
   $y = readonly Foo::$bar; // keyword required
 }
-function read_static2()[controlled]: void {
+function read_static2()[leak_safe]: void {
   $y = readonly Foo::$bar; // keyword required
 }
 ```

--- a/guides/hack/21-XHP/16-extending.md
+++ b/guides/hack/21-XHP/16-extending.md
@@ -387,7 +387,7 @@ use namespace Facebook\XHP\Core as x;
 final xhp class ui_get_status extends x\element {
 
   protected async function renderAsync(): Awaitable<x\node> {
-    $ch = \curl_init('https://status.fb.com/graph-api');
+    $ch = \curl_init('https://metastatus.com/graph-api');
     \curl_setopt($ch, \CURLOPT_USERAGENT, 'hhvm/user-documentation example');
     $status = await \HH\Asio\curl_exec($ch);
     return <x:frag>Status is: {$status}</x:frag>;

--- a/guides/hack/30-silencing-errors/05-error-codes.md
+++ b/guides/hack/30-silencing-errors/05-error-codes.md
@@ -51,11 +51,11 @@ which the typechecker is unaware of.
 Suggestions: Check your spelling. Use safe Hack APIs rather than
 legacy PHP APIs.
 
-## 4005: Array access on a type that doesn't support indexing
+## 4324: Array access on a type that doesn't support indexing
 
-```4005_array_access.hack no-auto-output
+```4324_array_access.hack no-auto-output
 function foo(int $m): void {
-  /* HH_FIXME[4005] Indexing a type that isn't indexable. */
+  /* HH_FIXME[4324] Indexing a type that isn't indexable. */
   $value = $m['foo'];
 }
 ```
@@ -66,6 +66,8 @@ leading to runtime type errors later.
 
 Suggestions: Refactor the code to use a Hack array or a
 `KeyedContainer`.
+
+** Note:** In previous versions of HHVM, error `4324` was known as error `4005`.
 
 ## 4006: Array append on an inappropriate type
 

--- a/src/codegen/PRODUCT_TAGS.php
+++ b/src/codegen/PRODUCT_TAGS.php
@@ -2,12 +2,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cb1185ac93592547f05c7f139b42211d>>
+ * @generated SignedSource<<3a5e67a90bcf26a3d8d406c0d568a52f>>
  */
 namespace HHVM\UserDocumentation;
 
 const dict<APIProduct, string> PRODUCT_TAGS = dict[
-  APIProduct::HACK => 'HHVM-4.154.0',
+  APIProduct::HACK => 'HHVM-4.160.0',
   APIProduct::HSL => 'v4.108.1',
   APIProduct::HSL_EXPERIMENTAL => 'v4.108.0',
 ];


### PR DESCRIPTION
Update HHVM to 4.160.

Other updates:
* Refactor `controlled` to `leak_safe` per https://github.com/facebook/hhvm/commit/0714f74784facee82975c441195def7dbf1f8b4b
* Remove FIX_ME 4005 per https://github.com/facebook/hhvm/commit/a439893a9daa74a08cf5c4cd8134536a532b69f4
* Updates status.fb.com to metastatus.com for automated tests