### PR TITLE
Increate MinSize of the autoscaling group to 2

### DIFF
--- a/.deploy/terraform/main.tf
+++ b/.deploy/terraform/main.tf
@@ -189,7 +189,7 @@ resource "aws_elastic_beanstalk_configuration_template" "docs" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name = "InstanceType"
-    value = "t3.small"
+    value = "t3.micro"
   }
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
@@ -235,7 +235,7 @@ resource "aws_elastic_beanstalk_configuration_template" "docs" {
   setting {
     namespace = "aws:autoscaling:asg"
     name = "MinSize"
-    value = "1"
+    value = "2"
   }
   setting {
     namespace = "aws:autoscaling:asg"


### PR DESCRIPTION
This PR should fix #1222 by increate the minimal size of the cluster to 2, so that there will be always an EC2 instance standby for deployment. It looks like a stupid fix but the cost of two `t3.micro` instances. is close to one `t3.small` instance.