### PR TITLE
Revert "Revert "Comment out the IPAddressType setting 

### DIFF
--- a/.deploy/terraform/prod.tf
+++ b/.deploy/terraform/prod.tf
@@ -24,7 +24,7 @@ resource "aws_elastic_beanstalk_application_version" "docs_prod" {
 
 resource "aws_elastic_beanstalk_environment" "docs_prod" {
   application = aws_elastic_beanstalk_application.docs.name
-  name = "hhvm-hack-docs-vpc-prod"
+  name = "hhvm-hack-docs-vpc-prod-${uuid()}"
   cname_prefix = "hack-hhvm-docs-vpc-prod"
   template_name = aws_elastic_beanstalk_configuration_template.docs.name
   version_label = aws_elastic_beanstalk_application_version.docs_prod.id

--- a/.deploy/terraform/staging.tf
+++ b/.deploy/terraform/staging.tf
@@ -24,7 +24,7 @@ resource "aws_elastic_beanstalk_application_version" "docs_staging" {
 
 resource "aws_elastic_beanstalk_environment" "docs_staging" {
   application = aws_elastic_beanstalk_application.docs.name
-  name = "hhvm-hack-docs-vpc-staging"
+  name = "hhvm-hack-docs-vpc-staging-${uuid()}"
   cname_prefix = "hack-hhvm-docs-vpc-staging"
   template_name = aws_elastic_beanstalk_configuration_template.docs.name
   version_label = aws_elastic_beanstalk_application_version.docs_staging.id


### PR DESCRIPTION
`IPAddressType` is an unsupported setting and it will result in failures in the newer version of Terraform AWS Provider (previously it was ignored)

This reverts commit e8efe59e9f28db7e4a944e5e3806d7c4a5f2687e.

This PR is a mitigation of #1222 