### PR TITLE
Randomize the Elastic Beanstalk environment names

### DIFF
--- a/.deploy/terraform/main.tf
+++ b/.deploy/terraform/main.tf
@@ -269,11 +269,13 @@ resource "aws_elastic_beanstalk_configuration_template" "docs" {
     name = "ManagedSecurityGroup"
     value = aws_security_group.public.id
   }
-  setting {
-    namespace = "aws:elbv2:loadbalancer"
-    name = "IPAddressType"
-    value =  "dualstack"
-  }
+  # Comment out the IPAddressType setting because it is an unsupported setting and it will result in failures in the newer version of Terraform AWS Provider (previously it was ignored)
+  #
+  # setting {
+  #   namespace = "aws:elbv2:loadbalancer"
+  #   name = "IPAddressType"
+  #   value =  "dualstack"
+  # }
   setting {
     namespace = "aws:elbv2:listener:80"
     name = "ListenerEnabled"

--- a/.deploy/terraform/prod.tf
+++ b/.deploy/terraform/prod.tf
@@ -24,7 +24,7 @@ resource "aws_elastic_beanstalk_application_version" "docs_prod" {
 
 resource "aws_elastic_beanstalk_environment" "docs_prod" {
   application = aws_elastic_beanstalk_application.docs.name
-  name = "hhvm-hack-docs-vpc-prod"
+  name = "hhvm-hack-docs-vpc-prod-${uuid()}"
   cname_prefix = "hack-hhvm-docs-vpc-prod"
   template_name = aws_elastic_beanstalk_configuration_template.docs.name
   version_label = aws_elastic_beanstalk_application_version.docs_prod.id

--- a/.deploy/terraform/staging.tf
+++ b/.deploy/terraform/staging.tf
@@ -24,7 +24,7 @@ resource "aws_elastic_beanstalk_application_version" "docs_staging" {
 
 resource "aws_elastic_beanstalk_environment" "docs_staging" {
   application = aws_elastic_beanstalk_application.docs.name
-  name = "hhvm-hack-docs-vpc-staging"
+  name = "hhvm-hack-docs-vpc-staging-${uuid()}"
   cname_prefix = "hack-hhvm-docs-vpc-staging"
   template_name = aws_elastic_beanstalk_configuration_template.docs.name
   version_label = aws_elastic_beanstalk_application_version.docs_staging.id


### PR DESCRIPTION
According to [the log](https://github.com/hhvm/user-documentation/runs/6734843871?check_suite_focus=true), Elastic Beanstalk environment cannot be updated under our current settings. This PR forces it to be recreated instead of being updated. Therefore this PR will result in some downtime when deploying a new version.

Note that a sophisticated solution to the immutable problem would be to configure a rolling policy for the Auto Scaling Group, but it would be too complicated and need further debugging. As a mitigation, this PR is simpler.