### PR TITLE
Revert "Revert "Randomize the Elastic Beanstalk environment names""

### DIFF
--- a/.deploy/terraform/prod.tf
+++ b/.deploy/terraform/prod.tf
@@ -24,7 +24,7 @@ resource "aws_elastic_beanstalk_application_version" "docs_prod" {
 
 resource "aws_elastic_beanstalk_environment" "docs_prod" {
   application = aws_elastic_beanstalk_application.docs.name
-  name = "hhvm-hack-docs-vpc-prod"
+  name = "hhvm-hack-docs-vpc-prod-${uuid()}"
   cname_prefix = "hack-hhvm-docs-vpc-prod"
   template_name = aws_elastic_beanstalk_configuration_template.docs.name
   version_label = aws_elastic_beanstalk_application_version.docs_prod.id

--- a/.deploy/terraform/staging.tf
+++ b/.deploy/terraform/staging.tf
@@ -24,7 +24,7 @@ resource "aws_elastic_beanstalk_application_version" "docs_staging" {
 
 resource "aws_elastic_beanstalk_environment" "docs_staging" {
   application = aws_elastic_beanstalk_application.docs.name
-  name = "hhvm-hack-docs-vpc-staging"
+  name = "hhvm-hack-docs-vpc-staging-${uuid()}"
   cname_prefix = "hack-hhvm-docs-vpc-staging"
   template_name = aws_elastic_beanstalk_configuration_template.docs.name
   version_label = aws_elastic_beanstalk_application_version.docs_staging.id


### PR DESCRIPTION
#1227 was merged unexpectedly and has been reverted. This is a recreation of #1227

This reverts commit 2b04410663e12f1512fcc3fb1469218c0a5a2468.