### PR TITLE
Add the GitHub Action job to update Docker image and push the image tag to the deploy branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,8 +10,6 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency: ${{github.ref}}
-
 jobs:
   build:
     name: Build and Test
@@ -44,6 +42,7 @@ jobs:
       - name: Export Docker image
         run: docker save hhvm/user-documentation:scratch -o hack-docs.tar
   update-docker-image:
+    concurrency: ${{github.ref}}
     if: github.event_name == 'push'
     name: Deploy
     needs: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
   schedule:
     - cron: '42 15 * * *'
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+concurrency: ${{github.ref}}
+
 jobs:
   build:
     name: Build and Test
@@ -28,10 +36,132 @@ jobs:
         run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hhast-lint
       - name: Verify codegen is unchanged
         run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hh-codegen-verify-signatures src
+      - name: Set up cache for Docker image
+        uses: actions/cache@v3
+        with:
+          key: ${{github.run_id}}
+          path: hack-docs.tar
       - name: Export Docker image
         run: docker save hhvm/user-documentation:scratch -o hack-docs.tar
-      - name: Save Docker image as build artifact
-        uses: actions/upload-artifact@v2
+  update-docker-image:
+    if: github.event_name == 'push'
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: download-tar
+        name: Set up cache for Docker image
+        uses: actions/cache@v3
         with:
-          name: docker-image
+          key: ${{github.run_id}}
           path: hack-docs.tar
+      - name: Import Docker image
+        run: docker load --input hack-docs.tar
+      - name: Build HHBC repo
+        run: |
+          mkdir ${{runner.temp}}/repo-out
+          docker run --rm \
+            -v ${{runner.temp}}/repo-out:/var/out \
+            -w /var/www \
+            hhvm/user-documentation:scratch \
+            .deploy/build-repo.sh
+      - name: Set image tag/name variables
+        run: |
+          DEPLOY_REV=$(git rev-parse --short HEAD)
+          HHVM_VERSION=$(awk '/APIProduct::HACK/{print $NF}' src/codegen/PRODUCT_TAGS.php | cut -f2 -d- | cut -f1-2 -d.)
+          IMAGE_TAG="HHVM-${HHVM_VERSION}-$(date +%Y-%m-%d)-${DEPLOY_REV}"
+          IMAGE_NAME="hhvm/user-documentation:$IMAGE_TAG"
+          echo "DEPLOY_REV=$DEPLOY_REV" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+      - name: Build repo-authoritative Docker image
+        run: |
+          cp hhvm.prod.ini ${{runner.temp}}/repo-out
+          cp .deploy/prod.Dockerfile ${{runner.temp}}/repo-out/Dockerfile
+          (
+            cd ${{runner.temp}}/repo-out
+            docker build -t ${IMAGE_NAME} .
+          )
+      - name: Log in to DockerHub
+        run: |
+          echo "${{secrets.DOCKERHUB_PASSWORD}}" | docker login -u "${{secrets.DOCKERHUB_USER}}" \
+            --password-stdin
+      - name: Push image to DockerHub
+        run: |
+          docker push "$IMAGE_NAME"
+      - if: github.ref == 'refs/heads/main'
+        name: Update latest tag to DockerHub
+        run: |
+          docker tag "$IMAGE_NAME" hhvm/user-documentation:latest
+          docker push "hhvm/user-documentation:latest"
+      - name: Checkout the existing deploy branch
+        id: checkout-existing-deploy-branch
+        continue-on-error: true
+        uses: actions/checkout@v3
+        with:
+          path: .var/tmp/deploy
+          ref: deploy/prod-${{github.ref_name}}
+      - name: Checkout the default deploy branch
+        if: steps.checkout-existing-deploy-branch.outcome == 'failure'
+        uses: actions/checkout@v3
+        with:
+          path: .var/tmp/deploy
+          ref: deploy/prod-main
+      - run: |
+          cat > .var/tmp/deploy/terraform.tfvars <<EOF
+          container_image = "$IMAGE_NAME"
+          EOF
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update the Docker image name to ${{env.IMAGE_TAG}}, which was built from ${{github.sha}}
+          repository: .var/tmp/deploy
+          create_branch: true
+          push_options: --force
+          branch: deploy/staging-${{github.run_id}}
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::223121549624:role/hhvm-user-documentation-github-actions
+          aws-region: us-west-2
+      - uses: hashicorp/setup-terraform@v2
+      - run: terraform init
+        working-directory: .var/tmp/deploy/
+      - id: terraform-staging-workspace
+        run: terraform workspace select "$WORKSPACE_NAME" || terraform workspace new "$WORKSPACE_NAME"
+        working-directory: .var/tmp/deploy/
+        env:
+          WORKSPACE_NAME: staging-${{github.run_id}}
+      - run: terraform apply -auto-approve
+        working-directory: .var/tmp/deploy/
+      - id: print-lb-dns-name
+        run: terraform output -raw aws_lb_lb_dns_name
+        working-directory: .var/tmp/deploy/
+      - name: Wait until the server is up
+        run: wget --retry-connrefused --retry-on-http-error=503,504 --tries=720 --no-http-keep-alive --output-document=- "http://${{steps.print-lb-dns-name.outputs.stdout}}/"
+      - name: Run test suite against staging
+        run: |
+          docker run --rm \
+            -w /var/www \
+            -e "REMOTE_TEST_HOST=${{steps.print-lb-dns-name.outputs.stdout}}" \
+            hhvm/user-documentation:scratch \
+            vendor/bin/hacktest \
+            --filter-groups remote \
+            tests/
+      - run: |
+          terraform workspace select "$WORKSPACE_NAME" && \
+          terraform destroy -auto-approve && \
+          git push origin :deploy/staging-${{github.run_id}}
+        if: always()
+        working-directory: .var/tmp/deploy/
+        env:
+          WORKSPACE_NAME: staging-${{github.run_id}}
+      - uses: ad-m/github-push-action@master
+        with:
+          directory: .var/tmp/deploy
+          branch: deploy/prod-${{github.ref_name}}
+      - run: terraform workspace select "$WORKSPACE_NAME" || terraform workspace new "$WORKSPACE_NAME"
+        working-directory: .var/tmp/deploy/
+        env:
+          WORKSPACE_NAME: prod-${{github.ref_name}}
+      - run: terraform apply -auto-approve
+        working-directory: .var/tmp/deploy/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           docker push "$IMAGE_NAME"
       - if: github.ref == 'refs/heads/main'
-        name: Update latest tag to DockerHub
+        name: Update the latest tag to DockerHub
         run: |
           docker tag "$IMAGE_NAME" hhvm/user-documentation:latest
           docker push "hhvm/user-documentation:latest"
@@ -112,42 +112,44 @@ jobs:
           cat > .var/tmp/deploy/terraform.tfvars <<EOF
           container_image = "$IMAGE_NAME"
           EOF
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::223121549624:role/hhvm-user-documentation-github-actions
+          aws-region: us-west-2
+      - uses: hashicorp/setup-terraform@v2
+      - name: Push to staging branch
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update the Docker image name to ${{env.IMAGE_TAG}}, which was built from ${{github.sha}}
           repository: .var/tmp/deploy
           create_branch: true
           push_options: --force
           branch: deploy/staging-${{github.run_id}}
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: arn:aws:iam::223121549624:role/hhvm-user-documentation-github-actions
-          aws-region: us-west-2
-      - uses: hashicorp/setup-terraform@v2
-      - run: terraform init
-        working-directory: .var/tmp/deploy/
-      - id: terraform-staging-workspace
-        run: terraform workspace select "$WORKSPACE_NAME" || terraform workspace new "$WORKSPACE_NAME"
+      - name: Deploy staging server
+        run: |
+          terraform init &&
+          (terraform workspace select "$WORKSPACE_NAME" || terraform workspace new "$WORKSPACE_NAME") &&
+          terraform apply -auto-approve
         working-directory: .var/tmp/deploy/
         env:
           WORKSPACE_NAME: staging-${{github.run_id}}
-      - run: terraform apply -auto-approve
-        working-directory: .var/tmp/deploy/
-      - id: print-lb-dns-name
+      - name: Print staging host name
+        id: print-staging-host-name
         run: terraform output -raw aws_lb_lb_dns_name
         working-directory: .var/tmp/deploy/
       - name: Wait until the server is up
-        run: wget --retry-connrefused --retry-on-http-error=503,504 --tries=720 --no-http-keep-alive --output-document=- "http://${{steps.print-lb-dns-name.outputs.stdout}}/"
+        run: wget --retry-connrefused --retry-on-http-error=503,504 --tries=720 --no-http-keep-alive --output-document=- "http://${{steps.print-staging-host-name.outputs.stdout}}/"
       - name: Run test suite against staging
         run: |
           docker run --rm \
             -w /var/www \
-            -e "REMOTE_TEST_HOST=${{steps.print-lb-dns-name.outputs.stdout}}" \
+            -e "REMOTE_TEST_HOST=${{steps.print-staging-host-name.outputs.stdout}}" \
             hhvm/user-documentation:scratch \
             vendor/bin/hacktest \
             --filter-groups remote \
             tests/
-      - run: |
+      - name: Destroy staging server and branch
+        run: |
           terraform workspace select "$WORKSPACE_NAME" && \
           terraform destroy -auto-approve && \
           git push origin :deploy/staging-${{github.run_id}}
@@ -155,13 +157,15 @@ jobs:
         working-directory: .var/tmp/deploy/
         env:
           WORKSPACE_NAME: staging-${{github.run_id}}
-      - uses: ad-m/github-push-action@master
+      - name: Push to prod branch
+        uses: ad-m/github-push-action@master
         with:
           directory: .var/tmp/deploy
           branch: deploy/prod-${{github.ref_name}}
-      - run: terraform workspace select "$WORKSPACE_NAME" || terraform workspace new "$WORKSPACE_NAME"
+      - name: Deploy prod server
+        run: |
+          (terraform workspace select "$WORKSPACE_NAME" || terraform workspace new "$WORKSPACE_NAME") &&
+          terraform apply -auto-approve
         working-directory: .var/tmp/deploy/
         env:
           WORKSPACE_NAME: prod-${{github.ref_name}}
-      - run: terraform apply -auto-approve
-        working-directory: .var/tmp/deploy/

--- a/tests/lib/RemotePageLoader.php
+++ b/tests/lib/RemotePageLoader.php
@@ -29,7 +29,7 @@ final class RemotePageLoader extends PageLoader {
           $scheme = 'http';
       }
     }
-    $url = $scheme.'://'.$test_host.$path;
+    $url = $scheme.'://'.($host_header ?? $test_host).$path;
     if ($query !== null) {
       $url .= '?'.$query;
     }
@@ -38,9 +38,7 @@ final class RemotePageLoader extends PageLoader {
     \curl_setopt($ch, \CURLOPT_HEADER, 1);
     \curl_setopt($ch, \CURLOPT_RETURNTRANSFER, 1);
 
-    if ($host_header) {
-      \curl_setopt($ch, \CURLOPT_HTTPHEADER, varray['Host: '.$host_header]);
-    }
+    \curl_setopt($ch, \CURLOPT_CONNECT_TO, vec['::'.$test_host.':']);
 
     $response = await \HH\Asio\curl_exec($ch);
     $status = (int)\curl_getinfo($ch, \CURLINFO_HTTP_CODE);


### PR DESCRIPTION
This PR adds the GitHub Action job to update Docker image and push the image tag to the deploy branch.

The idea is that changes in any source branch not under `deploy/` subpath, the GitHub Action should deploy it to a temporary staging Terraform workspace and run integration tests. Once the integration tests get passed, the GitHub Action should deploy it to a product Terraform workspace. Each Terraform workspace corresponds to a branch under the `deploy/` path.

## Use cases

### When a pull request is created from a forked repository

The GitHub Action job added by this PR would not run

### When a new branch on hhvm/user-documentation is created as a pull request source

The automatic integration tests should be executed against a temporary staging workspace. If the tests pass, the workspace `prod-<source branch name>` will be created for manual tests. Note that the branch specific prod workspace would not affect the prod-main workspace.

When the manual tests are done, the `deploy/prod-<source branch name>` can be deleted manually, then the Terraform workspace should be destroyed automatically with the help of #1242.

### When a pull request is merged to the `main` branch

The automatic integration tests should be executed against a temporary staging workspace. If the tests pass, the workspace `prod-main` will be updated, which is the site deployed at docs.hhvm.com.

## What does this PR do?

1. It builds the Docker image and upload it to Docker Hub like what we did previously in https://github.com/hhvm/user-documentation/blob/8cede4673fa5f541ac78999bfabd0daf3fc896c9/.github/workflows/build-and-test.yml
2. It creates a `deploy/staging-<unique id>` branch and deploys a temporary staging server
3. It runs integration tests
4. It deletes the `deploy/staging-<unique id>` branch and destroys the resources related to the temporary staging server
5. If the tests succeed, it creates a `deploy/prod-<source branch name>` branch and deploys the prod server

Note that the prod deployment branch will be created per source branch, while the temporary staging branch is per source revision.

This PR is stacked on #1243