### PR TITLE
Add Note Macro

### DIFF
--- a/guides/hack/40-contributing/12-information-macros.md
+++ b/guides/hack/40-contributing/12-information-macros.md
@@ -4,7 +4,7 @@ This website supports note, tip, caution, and danger macro messages.
 ```yamlmeta
 {
   "note": [
-    "This change was introduced in [HHVM 4.136](https://hhvm.com/blog/2021/11/19/hhvm-4.136.html)"
+    "This change was introduced in [HHVM 4.136](https://hhvm.com/blog/2021/11/19/hhvm-4.136.html)."
   ]
 }
 ```

--- a/guides/hack/40-contributing/12-information-macros.md
+++ b/guides/hack/40-contributing/12-information-macros.md
@@ -1,4 +1,15 @@
-This website supports tip, caution, and danger macro messages.
+This website supports note, tip, caution, and danger macro messages.
+
+## Note Message
+```yamlmeta
+{
+  "note": [
+    "This change was introduced in [HHVM 4.136](https://hhvm.com/blog/2021/11/19/hhvm-4.136.html)"
+  ]
+}
+```
+
+The `noreturn` type can be upcasted to `dynamic`.
 
 ## Tip Message
 ```yamlmeta
@@ -9,8 +20,6 @@ This website supports tip, caution, and danger macro messages.
 }
 ```
 Hack lets you write code quickly, while also having safety features built in, like static type checking.
-
-Here's another paragraph that you might find in the documentation set to make this section feel more natural.
 
 ## Caution Message
 ```yamlmeta
@@ -23,9 +32,7 @@ Here's another paragraph that you might find in the documentation set to make th
 
 This website maintains documentation on Hack features that are in the *experimental* phase.
 
-Here's another paragraph that you might find in the documentation set to make this section feel more natural.
-
-## Danger Message
+## Warning Message
 ```yamlmeta
 {
   "danger": [
@@ -35,5 +42,3 @@ Here's another paragraph that you might find in the documentation set to make th
 ```
 
 While inherently dangerous, you can use `AsyncMysqlConnection::query` to query a MySQL database client.
-
-Here's another paragraph that you might find in the documentation set to make this section feel more natural.

--- a/sass/basics.scss
+++ b/sass/basics.scss
@@ -42,6 +42,11 @@ a {
   padding: 0.5em;
   margin-bottom: 0.5em;
 
+  .note {
+    border: 1px solid $darkblue;
+    background-color: $lightestblue;
+  }
+
   .tip {
     border: 1px solid $green;
     background-color: $lightgreen;

--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -19,6 +19,7 @@ $green: #2db04b;
 $lightgreen: #DFF7E54D;
 
 $blue: #6986a6;
+$lightestblue: #e6e5ff4d;
 $lightblue: lighten($blue, 10%);
 $darkblue: darken($blue, 10%);
 

--- a/src/markdown-extensions/YamlFrontMatterBlock.php
+++ b/src/markdown-extensions/YamlFrontMatterBlock.php
@@ -44,6 +44,7 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
       self::getVersionRequirementMessage($data),
       self::getLibMessage($data),
       self::getFacebookMessages($data),
+      self::getNoteMessages($data),
       self::getTipMessages($data),
       self::getCautionMessages($data),
       self::getDangerMessages($data),
@@ -140,6 +141,26 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
     return new UnparsedBlocks\BlockSequence($messages);
   }
 
+  private static function getNoteMessages(
+    YAMLMeta $data,
+  ): ?UnparsedBlocks\Block {
+    $note_messages = $data['note'] ?? null;
+    if ($note_messages === null) {
+      return null;
+    }
+
+    $note_messages = Vec\map(
+      $note_messages,
+      $note_message ==> new UnparsedBlocks\InlineSequenceBlock(
+        '<div class="message note">'.
+        "**Note:**\n\n".
+        $note_message.
+        '</div>',
+      ),
+    );
+    return new UnparsedBlocks\BlockSequence($note_messages);
+  }
+
   private static function getTipMessages(
     YAMLMeta $data,
   ): ?UnparsedBlocks\Block {
@@ -192,7 +213,7 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
       $danger_messages,
       $danger_message ==> new UnparsedBlocks\InlineSequenceBlock(
         '<div class="message danger">'.
-        "**Danger:**\n\n".
+        "**Warning:**\n\n".
         $danger_message.
         '</div>',
       ),

--- a/src/typedefs.php
+++ b/src/typedefs.php
@@ -25,6 +25,7 @@ type YAMLMeta = shape(
     'composer' => string,
   ),
   ?'fbonly messages' => vec<string>,
+  ?'note' => vec<string>,
   ?'tip' => vec<string>,
   ?'caution' => vec<string>,
   ?'danger' => vec<string>,


### PR DESCRIPTION
* Add a note banner so that we can rework bolded note sections (like **Note:** Since XHP-Lib 3...) into cleaner, nicer information banners.
* Retitle "danger" to "warning" as it seems to be more appropriate of a message.
* Add working example to the Contributing section within the macros page.

<img width="1268" alt="image" src="https://user-images.githubusercontent.com/5179225/175341100-fe6c7cea-038a-4864-83c4-b05c5bd326b0.png">
