### PR TITLE
Add Banner to Comments Docs

### DIFF
--- a/guides/hack/02-source-code-fundamentals/10-comments.md
+++ b/guides/hack/02-source-code-fundamentals/10-comments.md
@@ -1,3 +1,11 @@
+```yamlmeta
+{
+  "note": [
+    "Hash comments (`#`) are no longer supported, and are a parse error since [HHVM 4.133](https://hhvm.com/blog/2021/10/26/hhvm-4.133.html)."
+  ]
+}
+```
+
 Hack has three comment syntaxes.
 
 ```show-comment-styles.hack no-auto-output

--- a/guides/hack/40-contributing/12-information-macros.md
+++ b/guides/hack/40-contributing/12-information-macros.md
@@ -4,7 +4,7 @@ This website supports note, tip, caution, and danger macro messages.
 ```yamlmeta
 {
   "note": [
-    "This change was introduced in [HHVM 4.136](https://hhvm.com/blog/2021/11/19/hhvm-4.136.html)"
+    "This change was introduced in [HHVM 4.136](https://hhvm.com/blog/2021/11/19/hhvm-4.136.html)."
   ]
 }
 ```

--- a/guides/hack/40-contributing/12-information-macros.md
+++ b/guides/hack/40-contributing/12-information-macros.md
@@ -1,4 +1,15 @@
-This website supports tip, caution, and danger macro messages.
+This website supports note, tip, caution, and danger macro messages.
+
+## Note Message
+```yamlmeta
+{
+  "note": [
+    "This change was introduced in [HHVM 4.136](https://hhvm.com/blog/2021/11/19/hhvm-4.136.html)"
+  ]
+}
+```
+
+The `noreturn` type can be upcasted to `dynamic`.
 
 ## Tip Message
 ```yamlmeta
@@ -9,8 +20,6 @@ This website supports tip, caution, and danger macro messages.
 }
 ```
 Hack lets you write code quickly, while also having safety features built in, like static type checking.
-
-Here's another paragraph that you might find in the documentation set to make this section feel more natural.
 
 ## Caution Message
 ```yamlmeta
@@ -23,9 +32,7 @@ Here's another paragraph that you might find in the documentation set to make th
 
 This website maintains documentation on Hack features that are in the *experimental* phase.
 
-Here's another paragraph that you might find in the documentation set to make this section feel more natural.
-
-## Danger Message
+## Warning Message
 ```yamlmeta
 {
   "danger": [
@@ -35,5 +42,3 @@ Here's another paragraph that you might find in the documentation set to make th
 ```
 
 While inherently dangerous, you can use `AsyncMysqlConnection::query` to query a MySQL database client.
-
-Here's another paragraph that you might find in the documentation set to make this section feel more natural.

--- a/sass/basics.scss
+++ b/sass/basics.scss
@@ -42,6 +42,11 @@ a {
   padding: 0.5em;
   margin-bottom: 0.5em;
 
+  .note {
+    border: 1px solid $darkblue;
+    background-color: $lightestblue;
+  }
+
   .tip {
     border: 1px solid $green;
     background-color: $lightgreen;

--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -19,6 +19,7 @@ $green: #2db04b;
 $lightgreen: #DFF7E54D;
 
 $blue: #6986a6;
+$lightestblue: #e6e5ff4d;
 $lightblue: lighten($blue, 10%);
 $darkblue: darken($blue, 10%);
 

--- a/src/markdown-extensions/YamlFrontMatterBlock.php
+++ b/src/markdown-extensions/YamlFrontMatterBlock.php
@@ -44,6 +44,7 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
       self::getVersionRequirementMessage($data),
       self::getLibMessage($data),
       self::getFacebookMessages($data),
+      self::getNoteMessages($data),
       self::getTipMessages($data),
       self::getCautionMessages($data),
       self::getDangerMessages($data),
@@ -140,6 +141,26 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
     return new UnparsedBlocks\BlockSequence($messages);
   }
 
+  private static function getNoteMessages(
+    YAMLMeta $data,
+  ): ?UnparsedBlocks\Block {
+    $note_messages = $data['note'] ?? null;
+    if ($note_messages === null) {
+      return null;
+    }
+
+    $note_messages = Vec\map(
+      $note_messages,
+      $note_message ==> new UnparsedBlocks\InlineSequenceBlock(
+        '<div class="message note">'.
+        "**Note:**\n\n".
+        $note_message.
+        '</div>',
+      ),
+    );
+    return new UnparsedBlocks\BlockSequence($note_messages);
+  }
+
   private static function getTipMessages(
     YAMLMeta $data,
   ): ?UnparsedBlocks\Block {
@@ -192,7 +213,7 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
       $danger_messages,
       $danger_message ==> new UnparsedBlocks\InlineSequenceBlock(
         '<div class="message danger">'.
-        "**Danger:**\n\n".
+        "**Warning:**\n\n".
         $danger_message.
         '</div>',
       ),

--- a/src/typedefs.php
+++ b/src/typedefs.php
@@ -25,6 +25,7 @@ type YAMLMeta = shape(
     'composer' => string,
   ),
   ?'fbonly messages' => vec<string>,
+  ?'note' => vec<string>,
   ?'tip' => vec<string>,
   ?'caution' => vec<string>,
   ?'danger' => vec<string>,


### PR DESCRIPTION
Clarifying `#` comment support, based on a conversation with the Slack team.

Dependent on https://github.com/hhvm/user-documentation/pull/1246.

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/5179225/175343037-cea8f06b-1423-4355-a068-0c1fef0efc70.png">
