### PR TITLE
Provide context on operators and fix incorrect precedence listings

### DIFF
--- a/guides/hack/03-expressions-and-operators/07-operator-precedence.md
+++ b/guides/hack/03-expressions-and-operators/07-operator-precedence.md
@@ -4,31 +4,33 @@ Operators higher in the table have a higher precedence (binding more
 tightly). Binary operators on the same row are evaluated according to their
 associativity.
 
-Operator | Associativity
------------- | ---------
-`\` | Left
-`[]` | Left
-`->` `?->` | Left
-`new`  | None
-`()` | Left
-`clone` | None
-`await` `++` `--` (postfix) | Right
-`(int)` `(float)` `(string)` `**` `@` `++` `--` (prefix) | Right
-`is` `as` `?as` | Left
-`!` `~` `+` `-` (one argument) | Right
-`*` `/` `%` | Left
-`.` `+` `-` (two arguments) | Left
-`<<` `>>` | Left
-`<` `<=` `>` `>=` `<=>` | None
-`===` `!==` `==` `!=` | None
-`&&` | Left
-`^` | Left
-`\|\|` | Left
-`&` | Left
-`\|` | Left
-`??` | Right
-`?` `:` `?:` | Left
-`\|>` | Left
-`=` `+=` `-=` `.=` `*=` `/=` `%=` `<<=` `>>=` `&=` `^=` `\|=` `??=` | Right
-`print` | Right
-`include` `require` | Left
+Operator | Description | Associativity
+------------ | --------- | ---------
+`\` | [Namespace separator](/hack/source-code-fundamentals/namespaces)  | Left
+`$` | [Name operator](/hack/source-code-fundamentals/names) for variables, constants, functions, and user-defined types | Right
+`::` | [Scope resolution](/hack/expressions-and-operators/scope-resolution)  | Left
+`[]` | [Index resolution]((/hack/expressions-and-operators/subscript)) for Hack Arrays and Strings | Left
+`->`, `?->` | [Property selection](/hack/expressions-and-operators/member-selection) and [null-safe property selection](/hack/expressions-and-operators/member-selection#null-safe-member-access) | Left
+`new` | [Object creation & Memory allocation](/hack/expressions-and-operators/new) | None
+`#`, `()` | [Enum class labels](/hack/built-in-types/enum-class-label) and [Function calling](/hack/functions/introduction) | Left
+`clone` | Object cloning (shallowly, not deeply) | None
+`readonly`, `await`, `++` `--` (postfix) | [Assigning readonly](/hack/readonly/explicit-readonly-keywords), [Suspending an async function](/hack/expressions-and-operators/await), and [Incrementing / Decrementing](/hack/expressions-and-operators/incrementing-and-decrementing) (postfix) | Right
+`(int)` `(float)` `(string)`, `**`, `@`, `++` `--` (prefix) | [Casting](/hack/expressions-and-operators/casting), [Exponentiation](/hack/expressions-and-operators/arithmetic#exponent), [Suppressing errors](/hack/expressions-and-operators/error-control), and [Incrementing / Decrementing](/hack/expressions-and-operators/incrementing-and-decrementing) (prefix) | Right
+`is`, `as` `?as` |[Type checks / Type assertions](/hack/expressions-and-operators/type-assertions) | Left
+`!`, `~`, `+` `-` (one argument) | [Logical negation](/hack/expressions-and-operators/logical-operators), [Bitwise negation](/hack/expressions-and-operators/bitwise-operators#bitwise-negation), and [Unary Addition / Subtraction](/hack/expressions-and-operators/arithmetic) | Right
+`*` `/` `%` | [Multiplication, Division, and Modulo](/hack/expressions-and-operators/arithmetic) | Left
+`.`, `+` `-` (two arguments) | [String concatenation](/hack/expressions-and-operators/string-concatenation) and [Addition / Subtraction](/hack/expressions-and-operators/arithmetic) | Left
+`<<` `>>` | [Bitwise shifting](/hack/expressions-and-operators/bitwise-operators) (left and right) | Left
+`<` `<=` `>` `>=`, `<=>` | [Comparison operators](/hack/expressions-and-operators/comparisons) and [Spaceship operator](/hack/expressions-and-operators/equality#the-spaceship-operator) | None
+`===` `!==` `==` `!=` | [Equality operators](/hack/expressions-and-operators/equality) | None
+`&` | [Bitwise AND](/hack/expressions-and-operators/bitwise-operators) | Left
+`^` | [Bitwise XOR](/hack/expressions-and-operators/bitwise-operators) | Left
+`\|` | [Bitwise OR](/hack/expressions-and-operators/bitwise-operators) | Left
+`&&` | [Logical AND](/hack/expressions-and-operators/logical-operators) | Left
+`\|\|` | [Logical OR](/hack/expressions-and-operators/logical-operators) | Left
+`??` | [Coalesce operator](/hack/expressions-and-operators/coalesce) | Right
+`?` `:`, `?:` | [Ternary evaluation](/hack/expressions-and-operators/ternary) and [Elvis operator](/hack/expressions-and-operators/ternary#elvis-operator) | Left
+`\|>` | [Pipe / Chain function calls](/hack/expressions-and-operators/pipe) | Left
+`=` `+=` `-=` `.=` `*=` `/=` `%=` `<<=` `>>=` `&=` `^=` `\|=`, `??=` | [Assignment operators](/hack/expressions-and-operators/assignment) and [Coalescing assignment operator](/hack/expressions-and-operators/coalesce#coalescing-assignment-operator) | Right
+`print` | Write to standard output | Right
+`include` `require` | [Include or Require a script](/hack/source-code-fundamentals/script-inclusion)| Left

--- a/guides/hack/03-expressions-and-operators/07-operator-precedence.md
+++ b/guides/hack/03-expressions-and-operators/07-operator-precedence.md
@@ -7,7 +7,6 @@ associativity.
 Operator | Description | Associativity
 ------------ | --------- | ---------
 `\` | [Namespace separator](/hack/source-code-fundamentals/namespaces)  | Left
-`$` | [Name operator](/hack/source-code-fundamentals/names) for variables, constants, functions, and user-defined types | Right
 `::` | [Scope resolution](/hack/expressions-and-operators/scope-resolution)  | Left
 `[]` | [Index resolution](/hack/expressions-and-operators/subscript) for Hack Arrays and Strings | Left
 `->`, `?->` | [Property selection](/hack/expressions-and-operators/member-selection) and [null-safe property selection](/hack/expressions-and-operators/member-selection#null-safe-member-access) | Left
@@ -32,5 +31,5 @@ Operator | Description | Associativity
 `?` `:`, `?:` | [Ternary evaluation](/hack/expressions-and-operators/ternary) and [Elvis operator](/hack/expressions-and-operators/ternary#elvis-operator) | Left
 `\|>` | [Pipe / Chain function calls](/hack/expressions-and-operators/pipe) | Left
 `=` `+=` `-=` `.=` `*=` `/=` `%=` `<<=` `>>=` `&=` `^=` `\|=`, `??=` | [Assignment operators](/hack/expressions-and-operators/assignment) and [Coalescing assignment operator](/hack/expressions-and-operators/coalesce#coalescing-assignment-operator) | Right
-`print` | Write to standard output | Right
+`echo` | [Write to standard output](/hack/expressions-and-operators/echo) | Right
 `include` `require` | [Include or Require a script](/hack/source-code-fundamentals/script-inclusion)| Left

--- a/guides/hack/03-expressions-and-operators/07-operator-precedence.md
+++ b/guides/hack/03-expressions-and-operators/07-operator-precedence.md
@@ -9,7 +9,7 @@ Operator | Description | Associativity
 `\` | [Namespace separator](/hack/source-code-fundamentals/namespaces)  | Left
 `$` | [Name operator](/hack/source-code-fundamentals/names) for variables, constants, functions, and user-defined types | Right
 `::` | [Scope resolution](/hack/expressions-and-operators/scope-resolution)  | Left
-`[]` | [Index resolution]((/hack/expressions-and-operators/subscript)) for Hack Arrays and Strings | Left
+`[]` | [Index resolution](/hack/expressions-and-operators/subscript) for Hack Arrays and Strings | Left
 `->`, `?->` | [Property selection](/hack/expressions-and-operators/member-selection) and [null-safe property selection](/hack/expressions-and-operators/member-selection#null-safe-member-access) | Left
 `new` | [Object creation & Memory allocation](/hack/expressions-and-operators/new) | None
 `#`, `()` | [Enum class labels](/hack/built-in-types/enum-class-label) and [Function calling](/hack/functions/introduction) | Left

--- a/guides/hack/03-expressions-and-operators/07-operator-precedence.md
+++ b/guides/hack/03-expressions-and-operators/07-operator-precedence.md
@@ -13,7 +13,7 @@ Operator | Description | Associativity
 `new` | [Object creation & Memory allocation](/hack/expressions-and-operators/new) | None
 `#`, `()` | [Enum class labels](/hack/built-in-types/enum-class-label) and [Function calling](/hack/functions/introduction) | Left
 `clone` | Object cloning (shallowly, not deeply) | None
-`readonly`, `await`, `++` `--` (postfix) | [Assigning readonly](/hack/readonly/explicit-readonly-keywords), [Suspending an async function](/hack/expressions-and-operators/await), and [Incrementing / Decrementing](/hack/expressions-and-operators/incrementing-and-decrementing) (postfix) | Right
+`readonly`, `await`, `++` `--` (postfix) | [Using readonly](/hack/readonly/explicit-readonly-keywords), [Suspending an async function](/hack/expressions-and-operators/await), and [Incrementing / Decrementing](/hack/expressions-and-operators/incrementing-and-decrementing) (postfix) | Right
 `(int)` `(float)` `(string)`, `**`, `@`, `++` `--` (prefix) | [Casting](/hack/expressions-and-operators/casting), [Exponentiation](/hack/expressions-and-operators/arithmetic#exponent), [Suppressing errors](/hack/expressions-and-operators/error-control), and [Incrementing / Decrementing](/hack/expressions-and-operators/incrementing-and-decrementing) (prefix) | Right
 `is`, `as` `?as` |[Type checks / Type assertions](/hack/expressions-and-operators/type-assertions) | Left
 `!`, `~`, `+` `-` (one argument) | [Logical negation](/hack/expressions-and-operators/logical-operators), [Bitwise negation](/hack/expressions-and-operators/bitwise-operators#bitwise-negation), and [Unary Addition / Subtraction](/hack/expressions-and-operators/arithmetic) | Right


### PR DESCRIPTION
## Changes
* Fixes #1212 - `&&` should be lower, was likely confused with `&`.
* Add reference links to explain and give context for the different Hack operators.

## Open Questions / Discussion
* Is `print` effectively [`echo`](https://docs.hhvm.com/hack/expressions-and-operators/echo)? 
* Is there a more appropriate link for `include` and `require`?
* Any keyword or operator that should not be publicized?
* Trying to avoid using "member" across the documentation set. @Wilfred, let me know if there's a better way to phrase `->` and `?->`.

## Before
<img width="1679" alt="image" src="https://user-images.githubusercontent.com/5179225/177425813-26678e2f-bbb7-49ef-823e-359edc334466.png">

## After
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/5179225/177425712-6d2c10d5-f959-447f-b95b-e228c35b2342.png">
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5179225/177425759-624fead5-048b-4575-83e2-fd18a468002f.png">
