### PR TITLE
Fix #613 - 404 on /hack/disposables

### DIFF
--- a/src/Guides.php
+++ b/src/Guides.php
@@ -41,6 +41,7 @@ final class Guides {
       GuidesProduct::HACK => dict[
         'async' => tuple('asynchronous-operations', null),
         'collections' => tuple('arrays-and-collections', 'introduction'),
+        'disposables' => tuple('classes', 'object-disposal'),
         'enums' => tuple('built-in-types', 'enum'),
         'lambdas' => tuple('functions', 'anonymous-functions'),
         'operators' => tuple('expressions-and-operators', null),


### PR DESCRIPTION
Fixes #613 by linking to [Classes: Object Disposal](https://docs.hhvm.com/hack/classes/object-disposal).