### PR TITLE
Rename fb⇝Meta in fbOnly block, try to fix #1129

### DIFF
--- a/src/markdown-extensions/YamlFrontMatterBlock.php
+++ b/src/markdown-extensions/YamlFrontMatterBlock.php
@@ -128,12 +128,12 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
       $messages,
       $message ==> new UnparsedBlocks\InlineSequenceBlock(
         '<div class="message api fbOnly">'.
-        "**Facebook Engineer?**\n\n".
+        "**Meta Engineer?**\n\n".
         '<p>'.
         $message.
         "</p>\n".
         '<!-- '.
-        'Not a Facebook engineer... yet? https://www.facebook.com/careers/'.
+        'Not a Meta engineer... yet? https://www.facebook.com/careers/'.
         " -->\n".
         '</div>',
       ),

--- a/src/markdown-extensions/YamlFrontMatterBlock.php
+++ b/src/markdown-extensions/YamlFrontMatterBlock.php
@@ -133,7 +133,7 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
         $message.
         "</p>\n".
         '<!-- '.
-        'Not a Meta engineer... yet? https://www.facebook.com/careers/'.
+        'Not a Meta engineer... yet? https://metacareers.com/'.
         " -->\n".
         '</div>',
       ),

--- a/src/markdown-extensions/YamlFrontMatterBlock.php
+++ b/src/markdown-extensions/YamlFrontMatterBlock.php
@@ -127,7 +127,7 @@ abstract class YamlFrontMatterBlock implements UnparsedBlocks\BlockProducer {
     $messages = Vec\map(
       $messages,
       $message ==> new UnparsedBlocks\InlineSequenceBlock(
-        '<div class="message api fbOnly">'.
+        '<div class="message api fbOnly" data-nosnippet>'.
         "**Meta Engineer?**\n\n".
         '<p>'.
         $message.


### PR DESCRIPTION
This seems like it should work. Fixes #1129 (maybe)

Google's docs on `data-nosnippet`:
https://developers.google.com/search/docs/advanced/robots/robots_meta_tag

Happy to split the commits! i was going for a stacked diff sorta thing here but it's been a while since i used GH ><
