### PR TITLE
Add instructions on upgrading via codespaces

### DIFF
--- a/updating.md
+++ b/updating.md
@@ -21,3 +21,50 @@ $ bin/update-versions --hhvm-tag=HHVM-a.b.c --hsl-tag=vx.y.z
 ```
 
 See `bin/update-versions --help` for more options.
+
+# Updating to a new version of HHVM and the HSL from a Codespace
+
+First, ensure that your Codespace has a large enough machine type to perform 
+these upgrade operations. At minimum, an 8-core, 64GB machine is usually necessary.
+
+As usual, run `update-versions` to update the targetted HHVM version. 
+By default, the script uses the latest, publicly-available HHVM verison.
+
+```
+$ bin/update-versions
+```
+
+Next, add a commit, push your branch, and create a new Codespace.
+
+Creating a new Codespace is necessary because, at this point, the version of HHVM running on the 
+Codespace and the targetted version of HHVM (for the upgrade) will be different.
+
+To check the active version on the machine, use this command:
+
+```
+$ hhvm --version
+```
+
+Next, from the project, update dependencies with:
+
+```
+$ php /usr/local/bin/composer update
+```
+
+Then, build the site again...
+
+```
+$ hhvm bin/build.php
+```
+
+... and restart the server...
+
+```
+$ hh_client restart
+```
+
+... and finish by invoking the test suite and fixing any issues caused by the upgrade.
+
+```
+$ hhvm vendor/bin/hacktest tests/
+```


### PR DESCRIPTION
There's a few extra steps to ensure that the version of HHVM used on your codespace matches the version that is being targeted for upgrade. The README details those steps.