### PR TITLE
Don't say 'capability' outside of contexts documentation

### DIFF
--- a/guides/hack/07-traits-and-interfaces/02-implementing-an-interface.md
+++ b/guides/hack/07-traits-and-interfaces/02-implementing-an-interface.md
@@ -1,7 +1,9 @@
-A class can implement a set of capabilities&mdash;herein called a *contract*---through what is called an interface. An *interface* is a set of
-method declarations and constants.  Note that the methods are only declared, not defined; that is, an interface defines a type consisting
+A class can implement a *contract* through an interface, which is a set of required
+method declarations and constants.  
+
+Note that the methods are only declared, not defined; that is, an interface defines a type consisting
 of *abstract* methods, where those methods are implemented by client classes as they see fit. An interface allows unrelated classes to
-implement the same facilities with the same names and types without requiring those classes to share a common base class.  For example:
+implement the same facilities with the same names and types without requiring those classes to share a common base class. For example:
 
 ```MyCollection.hack no-auto-output
 interface MyCollection {

--- a/guides/hack/07-traits-and-interfaces/traits-and-interfaces-summary.txt
+++ b/guides/hack/07-traits-and-interfaces/traits-and-interfaces-summary.txt
@@ -1,1 +1,1 @@
-Implementing class capabilities and optimizing code reuse.
+Mechanisms for code reuse and code constraint within classes.

--- a/guides/hack/11-built-in-types/25-tuples.md
+++ b/guides/hack/11-built-in-types/25-tuples.md
@@ -39,7 +39,7 @@ Here is a more exotic example of a type involve a tuple:
 
 This declares a nullable type for a tuple containing an `int` and a tuple, which in turn, contains a `string` and a `float`.
 
-For non-trivial tuple types, it can be cumbersome to write out the complete type. Fortunately, Hack provides a type-aliasing capability via
+For non-trivial tuple types, it can be cumbersome to write out the complete type. Fortunately, Hack provides type-aliasing via
 `newtype` (and `type`). For example:
 
 ```distance-between-Points.hack no-auto-output


### PR DESCRIPTION
Fixes #1260 and includes a new description for the Traits and Interfaces section.