### PR TITLE
Set role-duration-seconds to 7200

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,6 +113,7 @@ jobs:
           EOF
       - uses: aws-actions/configure-aws-credentials@v1
         with:
+          role-duration-seconds: 7000
           role-to-assume: arn:aws:iam::223121549624:role/hhvm-user-documentation-github-actions
           aws-region: us-west-2
       - uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
Set role-duration-seconds to 7200 in case that staging server takes a long time to start, e.g. https://github.com/hhvm/user-documentation/runs/7454035633?check_suite_focus=true