### PR TITLE
Mention postfix/prefix on increment guide

### DIFF
--- a/guides/hack/03-expressions-and-operators/37-incrementing-and-decrementing.md
+++ b/guides/hack/03-expressions-and-operators/37-incrementing-and-decrementing.md
@@ -42,3 +42,16 @@ $x = 0;
 $y = $x + 1;
 $x++;
 ```
+
+When used as a postfix the condition is evaluated before the variable is incrimented.
+A prefix works inversely.
+```Hack
+    $x = 0;
+    echo($x++);
+```
+This first example results in the output `0`, while the one below results in `1`,
+as the value of x is increased before it is printed.
+```Hack
+    $x = 0;
+    echo(++$x);
+```


### PR DESCRIPTION
As a part of #1216: Mention postfix and prefix on increment/decrement guide

Added a short text explaining the difference between a prefix and postfix use of the increment and decrement operators. Located at the bottom of the page, it uses two examples and gives a brief explanation.