### PR TITLE
Add memory requirement for the dev container (fixes #1293)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,5 +28,8 @@
 
   "extensions": [ "pranayagarwal.vscode-hack" ],
   "forwardPorts": [ 80 ],
-  "postCreateCommand": ".deploy/init.sh"
+  "postCreateCommand": ".deploy/init.sh",
+  "hostRequirements": {
+    "memory": "8gb" 
+  }
 }


### PR DESCRIPTION
GitHub Codespace would fail to initialize on a machine with 4 GB memory. This PR adds the requirement so that we would use a codespaces with at least 8 GB memory.