### PR TITLE
Added examples for Dict\fill_keys and Dict\from_values

### DIFF
--- a/api-examples/function.HH.Lib.Dict.fill_keys.md
+++ b/api-examples/function.HH.Lib.Dict.fill_keys.md
@@ -1,0 +1,6 @@
+```basic-usage.hack
+$keys = vec['k1', 'k2', 'k3', 'k4'];
+$value = 5;
+$dict = Dict\fill_keys($keys, $value);
+\print_r($dict);
+```

--- a/api-examples/function.HH.Lib.Dict.from_values.md
+++ b/api-examples/function.HH.Lib.Dict.from_values.md
@@ -1,0 +1,9 @@
+```hack.basic-usage.hack
+$values = vec[1, 2, 3, 4];
+$dict = Dict\from_values($values, $x ==> $x + 1);
+\print_r($dict);
+
+$values = vec[1, 2, 3, 4];
+$dict = Dict\from_values($values, $x ==> 5);
+\print_r($dict);
+```


### PR DESCRIPTION
<img width="633" alt="Screen Shot 2022-10-13 at 5 40 52 PM" src="https://user-images.githubusercontent.com/27273819/195736834-cb77266d-8f83-403d-875e-09b7ea83dedd.png">
<img width="835" alt="Screen Shot 2022-10-13 at 5 40 17 PM" src="https://user-images.githubusercontent.com/27273819/195736836-8c51b3b3-9f2e-4516-8b81-de79f7a540f5.png">


Passed all tests by running `./vendor/bin/hacktest tests/`:
Summary: 5102 test(s), 5102 passed, 0 failed, 0 skipped, 0 error(s).