### PR TITLE
Added example for Math\minva and added Math as common namespace

### DIFF
--- a/api-examples/function.HH.Lib.Math.minva.md
+++ b/api-examples/function.HH.Lib.Math.minva.md
@@ -1,0 +1,4 @@
+```basic-usage.hack
+$minval = Math\minva(1, 2, 3, 4, 5, 5, 4);
+echo "The min value is " . $minval;
+```

--- a/build/extracted-examples/api/hsl/function.HH.Lib.Math.minva/basic-usage.hack
+++ b/build/extracted-examples/api/hsl/function.HH.Lib.Math.minva/basic-usage.hack
@@ -1,0 +1,14 @@
+// WARNING: Contains some auto-generated boilerplate code, see:
+// HHVM\UserDocumentation\MarkdownExt\ExtractedCodeBlocks\FilterBase::addBoilerplate
+
+namespace HHVM\UserDocumentation\Api\Hsl\FunctionHHLibMathMinva\BasicUsage;
+
+use namespace HH\Lib\Math;
+
+<<__EntryPoint>>
+async function _main(): Awaitable<void> {
+  \init_docs_autoloader();
+
+  $minval = Math\minva(1, 2, 3, 4, 5, 5, 4);
+  echo "The min value is " . $minval;
+}

--- a/build/extracted-examples/api/hsl/function.HH.Lib.Math.minva/basic-usage.hack.hhvm.expect
+++ b/build/extracted-examples/api/hsl/function.HH.Lib.Math.minva/basic-usage.hack.hhvm.expect
@@ -1,0 +1,1 @@
+The min value is 1

--- a/build/extracted-examples/guides/hack/04-statements/09-try/simple.hack
+++ b/build/extracted-examples/guides/hack/04-statements/09-try/simple.hack
@@ -3,6 +3,8 @@
 
 namespace HHVM\UserDocumentation\Guides\Hack\Statements\Try\Simple;
 
+use namespace HH\Lib\Math;
+
 function do_it(int $x, int $y): void {
   try {
     $result = $x / $y;

--- a/src/markdown-extensions/extracted-code-blocks/FilterBase.php
+++ b/src/markdown-extensions/extracted-code-blocks/FilterBase.php
@@ -11,7 +11,7 @@
 
 namespace HHVM\UserDocumentation\MarkdownExt\ExtractedCodeBlocks;
 
-use namespace HH\Lib\{C, Dict, Keyset, Regex, Str, Vec};
+use namespace HH\Lib\{C, Dict, Keyset, Regex, Str, Vec, Math};
 use namespace Facebook\{Markdown, Markdown\Blocks};
 use namespace HHVM\UserDocumentation\MarkdownExt;
 use type HHVM\UserDocumentation\BuildPaths;
@@ -70,6 +70,7 @@ abstract class FilterBase extends Markdown\RenderFilter {
     'Regex',
     'Str',
     'Vec',
+    'Math',
   ];
 
   const dict<string, string> PATHS = dict[

--- a/src/markdown-extensions/extracted-code-blocks/FilterBase.php
+++ b/src/markdown-extensions/extracted-code-blocks/FilterBase.php
@@ -11,7 +11,7 @@
 
 namespace HHVM\UserDocumentation\MarkdownExt\ExtractedCodeBlocks;
 
-use namespace HH\Lib\{C, Dict, Keyset, Regex, Str, Vec, Math};
+use namespace HH\Lib\{C, Dict, Keyset, Math, Regex, Str, Vec};
 use namespace Facebook\{Markdown, Markdown\Blocks};
 use namespace HHVM\UserDocumentation\MarkdownExt;
 use type HHVM\UserDocumentation\BuildPaths;
@@ -67,10 +67,10 @@ abstract class FilterBase extends Markdown\RenderFilter {
     'C',
     'Dict',
     'Keyset',
+    'Math',
     'Regex',
     'Str',
     'Vec',
-    'Math',
   ];
 
   const dict<string, string> PATHS = dict[


### PR DESCRIPTION
Local testing ran through `./vendor/bin/hacktest tests/` and the below are the results:
Summary: 5111 test(s), 5111 passed, 0 failed, 0 skipped, 0 error(s).

<img width="1118" alt="Screen Shot 2022-10-24 at 5 27 41 PM" src="https://user-images.githubusercontent.com/27273819/197632947-7525c1e0-1c4d-445c-b704-1ee50abc4810.png">
