### PR TITLE
Add comment to Memoize attribute documentation

### DIFF
--- a/guides/hack/20-attributes/07-predefined-attributes.md
+++ b/guides/hack/20-attributes/07-predefined-attributes.md
@@ -255,6 +255,9 @@ You can clear the cache with `HH\clear_static_memoization`. This should only be 
 - the component being tested is meant to be immutable/idempotent for the entire request
 - the test needs to cover multiple initial states, where only one would truly be reachable in a single request
 
+NOTE: Putting Memoize attribute on a function will cause it to bind to the declaring class. Any uses of static:: constructs to retrieve
+definitions from subclasses will not work and can cause unexpected results.
+
 ### Exceptions
 
 Thrown exceptions are not memoized, showing by the increasing counter in this

--- a/guides/hack/20-attributes/07-predefined-attributes.md
+++ b/guides/hack/20-attributes/07-predefined-attributes.md
@@ -255,8 +255,8 @@ You can clear the cache with `HH\clear_static_memoization`. This should only be 
 - the component being tested is meant to be immutable/idempotent for the entire request
 - the test needs to cover multiple initial states, where only one would truly be reachable in a single request
 
-NOTE: Putting Memoize attribute on a function will cause it to bind to the declaring class. Any uses of static:: constructs to retrieve
-definitions from subclasses will not work and can cause unexpected results.
+NOTE: Putting Memoize attribute on static function will cause it to bind to the declaring class. Any uses of static:: constructs
+to retrieve definitions from subclasses will not work and can cause unexpected results. Use MemoizeLSB instead
 
 ### Exceptions
 


### PR DESCRIPTION
TIL that Memoize attribute will cause implementation to be memoized at declaring class level. If the code inside function uses any static:: constructs to retrieve definitions (or call into functions) from child class, these will fail as function is bound to the place in code where it's declared. 