### PR TITLE
Adding example code for Str\uppercase_l to the documentation

### DIFF
--- a/api-examples/function.HH.Lib.Str.uppercase_l.md
+++ b/api-examples/function.HH.Lib.Str.uppercase_l.md
@@ -1,0 +1,4 @@
+```basic-usage.hack
+$locale = \HH\Lib\Locale\create("en_US.UTF-8");
+$uppercase_string = Str\uppercase_l($locale, 'ifoo');
+echo "Get uppercase string with en_US.UTF-8: $uppercase_string \n";

--- a/build/extracted-examples/api/hsl/function.HH.Lib.Str.uppercase_l/basic-usage.hack
+++ b/build/extracted-examples/api/hsl/function.HH.Lib.Str.uppercase_l/basic-usage.hack
@@ -1,0 +1,15 @@
+// WARNING: Contains some auto-generated boilerplate code, see:
+// HHVM\UserDocumentation\MarkdownExt\ExtractedCodeBlocks\FilterBase::addBoilerplate
+
+namespace HHVM\UserDocumentation\Api\Hsl\FunctionHHLibStrUppercaseL\BasicUsage;
+
+use namespace HH\Lib\Str;
+
+<<__EntryPoint>>
+async function _main(): Awaitable<void> {
+  \init_docs_autoloader();
+
+  $locale = \HH\Lib\Locale\create("en_US.UTF-8");
+  $uppercase_string = Str\uppercase_l($locale, 'ifoo');
+  echo "Get uppercase string with en_US.UTF-8: $uppercase_string \n";
+}

--- a/build/extracted-examples/api/hsl/function.HH.Lib.Str.uppercase_l/basic-usage.hack.hhvm.expect
+++ b/build/extracted-examples/api/hsl/function.HH.Lib.Str.uppercase_l/basic-usage.hack.hhvm.expect
@@ -1,0 +1,1 @@
+Get uppercase string with en_US.UTF-8: IFOO 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/117761616/200650781-d7810a07-68e0-47cd-8620-4af5a4ca8ef6.png)

Add example for Str\uppercase_l