### PR TITLE
Documentation for the require class trait constraints

### DIFF
--- a/guides/hack/07-traits-and-interfaces/04-trait-and-interface-requirements.md
+++ b/guides/hack/07-traits-and-interfaces/04-trait-and-interface-requirements.md
@@ -11,6 +11,8 @@ require extends <class name>;
 require implements <interface name>;
 ```
 
+*Note:* the experimental `require class <class name>;` trait constraint is discussed [below](#traits__the-require-class-trait-constraints-experimental).
+
 To introduce an interface requirement, you can have one or more of following in your interface:
 
 ```Hack
@@ -108,6 +110,29 @@ function run(): void {
 
 **NOTE**: `require extends` should be taken literally. The class *must* extend the required class; thus the actual required class
 **does not** meet that requirement. This is to avoid some subtle circular dependencies when checking requirements.
+
+#### The `require class` trait constraints (experimental)
+
+A `require class <class name>;` trait constraint in a trait specifies that the trait can only be used by the
+_non-generic, _final_, class `<class name>`.  This contrasts with the `require extends t;` constraints that allow the trait to be used by an arbitrary _strict_ subtype of `t`.
+By relaxing the strict subtype constraint of `require extends`, `require class` constraints allow splitting the implementation of a class into a
+class and one (or multiple) traits, as in the following:
+
+```
+<<file:__EnableUnstableFeatures('require_class')>>
+
+trait T {
+  require class C;
+  public function foo(): void {
+    $this->bar();
+  }
+}
+
+final class C {
+  use T;
+  public function bar(): void {}
+}
+```
 
 ## Interfaces
 


### PR DESCRIPTION
Documentation for the require class trait constraints.  The example is not checked at all as doc is running an old HHVM version. This supersedes pull request 1323 (will abandon).