### PR TITLE
Add example for Math\max_by function documentation

### DIFF
--- a/api-examples/function.HH.Lib.Math.max_by.md
+++ b/api-examples/function.HH.Lib.Math.max_by.md
@@ -1,0 +1,9 @@
+```
+$items = vec[tuple('foo', 9), tuple('bar', 8), tuple('baz', 7)];
+$maxItem = Math\max_by($items, $item ==> $item[1]);
+echo "The max item is " . $maxItem[0];
+```
+Ouput
+```
+The max item is foo
+```


### PR DESCRIPTION
The screenshot after the change is as follows:
<img width="1527" alt="Screenshot 2023-02-17 at 14 50 44" src="https://user-images.githubusercontent.com/7930497/219674830-1f76a81c-4420-46af-b97d-7597a6aadb01.png">
