### PR TITLE
Fix mistake in documentation, Getting Started: Starting a Real Project, Adding Functions or Classes

### DIFF
--- a/guides/hack/01-getting-started/03-starting-a-real-project.md
+++ b/guides/hack/01-getting-started/03-starting-a-real-project.md
@@ -140,7 +140,7 @@ numbers; save the following as `src/square_vec.hack`:
 ```Hack
 use namespace HH\Lib\Vec;
 
-function square_vec(vec<num> $numbers): vec<num> {
+function square_vec(vec<num> $numbers): vec<int> {
   return Vec\map($numbers, $number ==> $number * $number);
 }
 ```


### PR DESCRIPTION
https://github.com/hhvm/user-documentation/issues/1351

## Where is the problem?
Documentation, Getting Started: Starting a Real Project, Adding Functions or Classes section, code example

## What is the problem?
The code example is

```hack
use namespace HH\Lib\Vec;

function square_vec(vec<num> $numbers): vec<num> {
  return Vec\map($numbers, $number ==> $number * $number);
}
```

It then notes "If you then run hh_client, it will tell you of a mistake... To fix this, change the return type of the function from vec to vec."

However the return type is already num in the example.