### PR TITLE
Add examples for 16 HSL functions

### DIFF
--- a/api-examples/function.HH.Lib.Keyset.chunk.md
+++ b/api-examples/function.HH.Lib.Keyset.chunk.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\chunk(vec[1,2,3,4,5,6],3);
+print_r($result);
+//result: [keyset[1,2,3], keyset[4,5,6]]
+
+$result = Keyset\chunk(vec[1,2,2,3,4,5],3);
+print_r($result);
+//result: [keyset[1,2], keyset[3,4,5]]
+```

--- a/api-examples/function.HH.Lib.Keyset.diff.md
+++ b/api-examples/function.HH.Lib.Keyset.diff.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\diff(keyset[1,2,3,4,5,6], vec[1,2,3]);
+print_r($result);
+//result: keyset[4,5,6]
+
+$result = Keyset\diff(vec[1,2,3,4,5,6], keyset[]);
+print_r($result);
+//result: keyset[1,2,3,4,5,6]
+```

--- a/api-examples/function.HH.Lib.Keyset.drop.md
+++ b/api-examples/function.HH.Lib.Keyset.drop.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\drop(keyset[1,2,3,4,5,6], 3);
+print_r($result);
+//result: keyset[4,5,6]
+
+$result = Keyset\drop(vec[1,2,3,4,5,6], 0);
+print_r($result);
+//result: keyset[1,2,3,4,5,6]
+```

--- a/api-examples/function.HH.Lib.Keyset.equal.md
+++ b/api-examples/function.HH.Lib.Keyset.equal.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Keyset\equal(keyset[1,2,3,4], keyset[1,2,3,4]);
+print_r($result);
+//result: true
+
+$result = Keyset\equal(keyset[1,2,3,4], keyset[4,2,3,1]);
+print_r($result);
+//result: true
+
+$result = Keyset\equal(keyset[1,2,3,4],  keyset[1,2,3,4,5]);
+print_r($result);
+//result: false
+```

--- a/api-examples/function.HH.Lib.Keyset.filter.md
+++ b/api-examples/function.HH.Lib.Keyset.filter.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Keyset\filter(keyset[1,2,3,4], $val ==> $val%2==0);
+print_r($result);
+//result: keyset[2,4]
+
+$result = Keyset\filter(keyset[1,2,3,4], $val ==> $val==0);
+print_r($result);
+//result: keyset[]
+
+$result = Keyset\filter(keyset[1,2,3,4],  $val ==> $val == $val);
+print_r($result);
+//result: keyset[1,2,3,4]
+```

--- a/api-examples/function.HH.Lib.Keyset.filter_nulls.md
+++ b/api-examples/function.HH.Lib.Keyset.filter_nulls.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Keyset\filter_nulls(vec<int>[1,2,3,4,null, null]);
+print_r($result);
+//result: keyset[1,2,3,4]
+
+$result = Keyset\filter_nulls(vec[1,2,3,4]);
+print_r($result);
+//result: keyset[1,2,3,4]
+
+$result = Keyset\filter_nulls(vec[]);
+print_r($result);
+//result: keyset[]
+```

--- a/api-examples/function.HH.Lib.Keyset.filter_with_key.md
+++ b/api-examples/function.HH.Lib.Keyset.filter_with_key.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Keyset\filter_with_key(dict[1 => 2, 2 => 4, 3 => 5], ($key, $val) ==> $val%2==0);
+print_r($result);
+//result: keyset[2,4]
+
+$result = Keyset\filter_with_key(dict[1 => 2, 2 => 4], ($key, $val) ==> $val==0);
+print_r($result);
+//result: keyset[]
+
+$result = Keyset\filter_with_key(dict[1 => 2, 2 => 4, 3 => 5],  ($key, $val) ==> $val == $val);
+print_r($result);
+//result: keyset[2,4,5]
+```

--- a/api-examples/function.HH.Lib.Keyset.flatten.md
+++ b/api-examples/function.HH.Lib.Keyset.flatten.md
@@ -1,0 +1,16 @@
+```basic-usage.hack
+$example_set = vec[keyset[1,2,3,4,5],keyset[98, 99]];
+$result = Keyset\flatten($example_set);
+print_r($result);
+//result: keyset[1,2,3,4,5,98,99]
+
+$example_set = vec[vec[1,2,3,4,5,5,5,5]];
+$result = Keyset\flatten($example_set);
+print_r($result);
+//result: keyset[1,2,3,4,5]
+
+$example_set = vec[];
+$result = Keyset\flatten($example_set);
+print_r($result);
+//result: keyset[]
+```

--- a/api-examples/function.HH.Lib.Keyset.intersect.md
+++ b/api-examples/function.HH.Lib.Keyset.intersect.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$example_set1 = keyset[1,2,3,4,5];
+$example_set2 = keyset[1,3];
+
+$result = Keyset\intersect($example_set1, $example_set2);
+print_r($result);
+//result: keyset[1,3]
+
+$example_vec3 = keyset[6,7];
+$result = Keyset\intersect($example_set1, $example_vec3);
+print_r($result);
+//result: keyset[]
+```

--- a/api-examples/function.HH.Lib.Keyset.keys.md
+++ b/api-examples/function.HH.Lib.Keyset.keys.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\keys(dict[1 => 100, 33 => 400 ]);
+print_r($result);
+//result: keyset[1,33]
+
+$result = Keyset\keys(dict[]);
+print_r($result);
+//result: keyset[]
+```

--- a/api-examples/function.HH.Lib.Keyset.map.md
+++ b/api-examples/function.HH.Lib.Keyset.map.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\map(keyset[1,2,3,4], $val ==> $val*2);
+print_r($result);
+//result: keyset[2,4,6,8]
+
+$result = Keyset\map(keyset[1,2,3,4], $val ==> $val);
+print_r($result);
+//result: keyset[1,2,3,4]
+```

--- a/api-examples/function.HH.Lib.Keyset.map_with_key.md
+++ b/api-examples/function.HH.Lib.Keyset.map_with_key.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\map_with_key(dict[1 => 2, 2 => 4, 3 => 5], ($key, $val) ==> $val*$key);
+print_r($result);
+//result: keyset[2,8,15]
+
+$result = Keyset\map_with_key(dict[1 => 2, 2 => 4], ($key, $val) ==> $key);
+print_r($result);
+//result: keyset[1,2]
+```

--- a/api-examples/function.HH.Lib.Keyset.partition.md
+++ b/api-examples/function.HH.Lib.Keyset.partition.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\partition(keyset[1,2,3,4], $val ==> $val%2==0);
+print_r($result);
+//result: vec[keyset[2,4], keyset[1,3]]
+
+$result = Keyset\partition(keyset[1,2,3,4], $val ==> $val==0);
+print_r($result);
+//result: vec[keyset[], keyset[1,2,3,4]]
+```

--- a/api-examples/function.HH.Lib.Keyset.sort.md
+++ b/api-examples/function.HH.Lib.Keyset.sort.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\sort(keyset[1,200, 5]);
+print_r($result);
+//result: keyset[1,5,200]
+
+$result = Keyset\sort(keyset[100,2000,3,4]);
+print_r($result);
+//result: keyset[3,4,100,2000]
+```

--- a/api-examples/function.HH.Lib.Keyset.take.md
+++ b/api-examples/function.HH.Lib.Keyset.take.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\take(keyset[1,200, 5], 2);
+print_r($result);
+//result: keyset[1,200]
+
+$result = Keyset\take(keyset[100,2000,3,4], 0);
+print_r($result);
+//result: keyset[]
+```

--- a/api-examples/function.HH.Lib.Keyset.union.md
+++ b/api-examples/function.HH.Lib.Keyset.union.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Keyset\union(keyset[1,2], vec[4,5] );
+print_r($result);
+//result: keyset[1,2,4,5]
+
+$result = Keyset\union(keyset[1,2], vec[3,3,4,5] );
+print_r($result);
+//result: keyset[1,2,3,4,5]
+```


### PR DESCRIPTION
Added examples for 16 keyset HSL functions. Examples help with quick understanding of the functions and are a standard part of language documentation.

Sample screenshot
<img width="1169" alt="image" src="https://github.com/hhvm/user-documentation/assets/14361957/d7375459-4565-4a27-b08d-fd6e059f260b">
