### PR TITLE
Add examples for string HSL functions

### DIFF
--- a/api-examples/function.HH.Lib.Str.capitalize.md
+++ b/api-examples/function.HH.Lib.Str.capitalize.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Str\capitalize("example_string");
+echo($result);
+// result "Example_string"
+
+$result = Str\capitalize("Example_string");
+echo($result);
+// result "Example_string"
+```

--- a/api-examples/function.HH.Lib.Str.chunk.md
+++ b/api-examples/function.HH.Lib.Str.chunk.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Str\chunk("example_string", 5);
+print_r($result);
+//result: ["examp", "le_st", "ring"]
+
+$result = Str\chunk("example_string", 50);
+print_r($result);
+//result: ["example_string"]
+```

--- a/api-examples/function.HH.Lib.Str.contains.md
+++ b/api-examples/function.HH.Lib.Str.contains.md
@@ -1,0 +1,17 @@
+```basic-usage.hack
+$result = Str\contains("example_string", "example");
+echo($result);
+//result: true 
+
+$result = Str\contains("example_string", "EXAMPLE"); // different case
+echo($result);
+//result: false
+
+$result = Str\contains("example_string", "example", 2); // with offset
+echo($result);
+//result: false 
+
+$result = Str\contains("example_string", "uncontained");
+echo($result);
+//result: false 
+```

--- a/api-examples/function.HH.Lib.Str.ends_with.md
+++ b/api-examples/function.HH.Lib.Str.ends_with.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Str\ends_with("example_string", "string");
+echo($result);
+//result: true
+
+$result = Str\ends_with("example_string", "STRING");
+echo($result);
+//result: false
+
+$result = Str\ends_with("example_string", "uncontained");
+echo($result);
+// result false
+```

--- a/api-examples/function.HH.Lib.Str.ends_with_ci.md
+++ b/api-examples/function.HH.Lib.Str.ends_with_ci.md
@@ -1,0 +1,11 @@
+```basic-usage.hack
+$result = Str\ends_with_ci("example_string", "string");
+echo($result);
+//result: true
+$result = Str\ends_with_ci("example_string", "STRING");
+echo($result);
+//result: true
+$result = Str\ends_with_ci("example_string", "uncontained");
+echo($result);
+//result: false
+```

--- a/api-examples/function.HH.Lib.Str.length.md
+++ b/api-examples/function.HH.Lib.Str.length.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Str\length("example_string");
+echo($result);
+//result: 14
+
+$result = Str\length("");
+echo($result);
+//result: 0 
+```

--- a/api-examples/function.HH.Lib.Str.replace.md
+++ b/api-examples/function.HH.Lib.Str.replace.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Str\replace("example_string", "string", "replacement");
+echo($result);
+//result: "example_replacement"
+
+$result = Str\replace("example_string", "STRING", "replacement");
+echo($result);
+//result: "example_string"
+
+$result = Str\replace("example_string", "uncontained", "replacement");
+echo($result);
+//result: "example_string"
+```

--- a/api-examples/function.HH.Lib.Str.replace_ci.md
+++ b/api-examples/function.HH.Lib.Str.replace_ci.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Str\replace_ci("example_string", "string", "replacement");
+echo($result);
+//result: example_replacement
+
+$result = Str\replace_ci("example_string", "STRING", "replacement");
+echo($result);
+//result: example_replacement
+
+$result = Str\replace_ci("example_string", "uncontained", "replacement");
+echo($result);
+//result: example_string
+```

--- a/api-examples/function.HH.Lib.Str.replace_every.md
+++ b/api-examples/function.HH.Lib.Str.replace_every.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Str\replace_every("example_string", dict["example"=>"test", "string"=>"value"]);
+echo($result);
+//result: test_value
+
+$result = Str\replace_every("example_string", dict["EXAMPLE"=>"test", "STRING"=>"value"]);
+echo($result);
+//result: example_string
+
+$result = Str\replace_every("example_string", dict["uncontained"=>"test", "uncontained_2"=>"value"]);
+echo($result);
+//result: example_string
+```

--- a/api-examples/function.HH.Lib.Str.replace_every_ci.md
+++ b/api-examples/function.HH.Lib.Str.replace_every_ci.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Str\replace_every_ci("example_string", dict["example"=>"test", "string"=>"value"]);
+echo($result);
+//result: test_value
+
+$result = Str\replace_every_ci("example_string", dict["EXAMPLE"=>"test", "STRING"=>"value"]);
+echo($result);
+//result: test_value
+
+$result = Str\replace_every_ci("example_string", dict["uncontained"=>"test", "uncontained_2"=>"value"]);
+echo($result);
+//result: example_string
+```

--- a/api-examples/function.HH.Lib.Str.reverse.md
+++ b/api-examples/function.HH.Lib.Str.reverse.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Str\reverse("example_string");
+echo($result);
+//result: "gnirts_elpmaxe"
+
+$result = Str\reverse("Example_string");
+echo($result);
+//result:"gnirts_elpmaxE"
+
+$result = Str\reverse("");
+echo($result);
+//result: ""
+```

--- a/api-examples/function.HH.Lib.Str.search.md
+++ b/api-examples/function.HH.Lib.Str.search.md
@@ -1,0 +1,17 @@
+```basic-usage.hack
+$result = Str\search("example_string", "example");
+echo($result);
+//result: 0
+
+$result = Str\search("example_string", "EXAMPLE");
+echo($result);
+//result: null
+
+$result = Str\search("example_string", "example", 2); // with offset
+echo($result);
+//result: null
+
+$result = Str\search("example_string", "uncontained");
+echo($result);
+//result: null
+```

--- a/api-examples/function.HH.Lib.Str.search_ci.md
+++ b/api-examples/function.HH.Lib.Str.search_ci.md
@@ -1,0 +1,17 @@
+```basic-usage.hack
+$result = Str\search_ci("example_string", "example");
+echo($result);
+//result: 0
+
+$result = Str\search_ci("example_string", "EXAMPLE");
+echo($result);
+//result: 0
+
+$result = Str\search_ci("example_string", "example", 2); // with offset
+echo($result);
+//result: null
+
+$result = Str\search_ci("example_string", "uncontained");
+echo($result);
+//result: null
+```

--- a/api-examples/function.HH.Lib.Str.slice.md
+++ b/api-examples/function.HH.Lib.Str.slice.md
@@ -1,0 +1,17 @@
+```basic-usage.hack
+$result = Str\slice("example_string", 5);
+echo($result);
+//result: "le_string"
+
+$result = Str\slice("example_string", 5, 1);
+echo($result);
+//result: "l"
+
+$result = Str\slice("example_string", 2, 0);
+echo($result);
+//result: ""
+
+$result = Str\slice("example_string", 1000);
+echo($result);
+//result: <Throws exception>
+```

--- a/api-examples/function.HH.Lib.Str.starts_with.md
+++ b/api-examples/function.HH.Lib.Str.starts_with.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Str\starts_with("example_string", "example");
+echo($result);
+//result: true
+
+$result = Str\starts_with("example_string", "EXAMPLE");
+echo($result);
+//result: false
+
+$result = Str\starts_with("example_string", "string");
+echo($result);
+//result: false
+```

--- a/api-examples/function.HH.Lib.Str.starts_with_ci.md
+++ b/api-examples/function.HH.Lib.Str.starts_with_ci.md
@@ -1,0 +1,13 @@
+```basic-usage.hack
+$result = Str\starts_with_ci("example_string", "example");
+echo($result);
+//result: true
+
+$result = Str\starts_with_ci("example_string", "EXAMPLE");
+echo($result);
+//result: true
+
+$result = Str\starts_with_ci("example_string", "string");
+echo($result);
+//result: false
+```

--- a/api-examples/function.HH.Lib.Str.trim.md
+++ b/api-examples/function.HH.Lib.Str.trim.md
@@ -1,0 +1,9 @@
+```basic-usage.hack
+$result = Str\trim("example_string    ");
+echo($result);
+//result: "example_string"
+
+$result = Str\trim("   example_string  ");
+echo($result);
+//result: "example_string"
+```

--- a/api-examples/function.HH.Lib.Str.uppercase.md
+++ b/api-examples/function.HH.Lib.Str.uppercase.md
@@ -3,4 +3,5 @@ $string = "hhvm";
 
 $string_upper = Str\uppercase($string);
 echo "Uppercase string: $string_upper \n";
+//result: Uppercase string: HHVM
 ```


### PR DESCRIPTION
Added examples for 16 keyset HSL functions. Examples help with quick understanding of the functions and are a standard part of language documentation.

![image](https://github.com/hhvm/user-documentation/assets/14361957/ab8181e4-fd18-4dca-afd2-f141f45dc10e)

