### PR TITLE
Move Docker image from HHVM to Meta org

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,22 +27,22 @@ jobs:
           docker pull hhvm/hhvm:${{matrix.hhvm}}-latest
           docker pull hhvm/hhvm-proxygen:${{matrix.hhvm}}-latest
       - name: Build
-        run: docker build -t hhvm/user-documentation:scratch -f .deploy/built-site.Dockerfile .
+        run: docker build -t meta/hhvm-user-documentation:scratch -f .deploy/built-site.Dockerfile .
       - name: Typecheck
-        run: docker run --rm -w /var/www hhvm/user-documentation:scratch hh_server --check .
+        run: docker run --rm -w /var/www meta/hhvm-user-documentation:scratch hh_server --check .
       - name: Run tests
-        run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hacktest tests/
+        run: docker run --rm -w /var/www meta/hhvm-user-documentation:scratch vendor/bin/hacktest tests/
       - name: Lint
-        run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hhast-lint
+        run: docker run --rm -w /var/www meta/hhvm-user-documentation:scratch vendor/bin/hhast-lint
       - name: Verify codegen is unchanged
-        run: docker run --rm -w /var/www hhvm/user-documentation:scratch vendor/bin/hh-codegen-verify-signatures src
+        run: docker run --rm -w /var/www meta/hhvm-user-documentation:scratch vendor/bin/hh-codegen-verify-signatures src
       - name: Set up cache for Docker image
         uses: actions/cache@v3
         with:
           key: ${{github.run_id}}
           path: hack-docs.tar
       - name: Export Docker image
-        run: docker save hhvm/user-documentation:scratch -o hack-docs.tar
+        run: docker save meta/hhvm-user-documentation:scratch -o hack-docs.tar
   update-docker-image:
     concurrency: ${{github.ref}}
     if: github.ref == 'refs/heads/main'
@@ -65,14 +65,14 @@ jobs:
           docker run --rm \
             -v ${{runner.temp}}/repo-out:/var/out \
             -w /var/www \
-            hhvm/user-documentation:scratch \
+            meta/hhvm-user-documentation:scratch \
             .deploy/build-repo.sh
       - name: Set image tag/name variables
         run: |
           DEPLOY_REV=$(git rev-parse --short HEAD)
           HHVM_VERSION=$(awk '/APIProduct::HACK/{print $NF}' src/codegen/PRODUCT_TAGS.php | cut -f2 -d- | cut -f1-2 -d.)
           IMAGE_TAG="HHVM-${HHVM_VERSION}-$(date +%Y-%m-%d)-${DEPLOY_REV}"
-          IMAGE_NAME="hhvm/user-documentation:$IMAGE_TAG"
+          IMAGE_NAME="meta/hhvm-user-documentation:$IMAGE_TAG"
           echo "DEPLOY_REV=$DEPLOY_REV" >> $GITHUB_ENV
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
@@ -94,8 +94,8 @@ jobs:
       - if: github.ref == 'refs/heads/main'
         name: Update the latest tag to DockerHub
         run: |
-          docker tag "$IMAGE_NAME" hhvm/user-documentation:latest
-          docker push "hhvm/user-documentation:latest"
+          docker tag "$IMAGE_NAME" meta/hhvm-user-documentation:latest
+          docker push "meta/hhvm-user-documentation:latest"
       - name: Checkout the existing deploy branch
         id: checkout-existing-deploy-branch
         continue-on-error: true
@@ -146,7 +146,7 @@ jobs:
           docker run --rm \
             -w /var/www \
             -e "REMOTE_TEST_HOST=${{steps.print-staging-host-name.outputs.stdout}}" \
-            hhvm/user-documentation:scratch \
+            meta/hhvm-user-documentation:scratch \
             vendor/bin/hacktest \
             --filter-groups remote \
             tests/

--- a/guides/hack/40-contributing/01-introduction.md
+++ b/guides/hack/40-contributing/01-introduction.md
@@ -74,12 +74,12 @@ automatically.
 
 If you want to see old versions of the docs, we provide [regular
 Docker images of this
-site](https://hub.docker.com/r/hhvm/user-documentation/tags). This is
+site](https://hub.docker.com/r/meta/hhvm-user-documentation/tags). This is
 not suitable for development, but it's useful if you're working with
 an old HHVM/Hack version.
 
 1. Install [Docker](https://docs.docker.com/engine/installation/).
-2. Start a container with `docker run -p 8080:80 -d hhvm/user-documentation`.
+2. Start a container with `docker run -p 8080:80 -d meta/hhvm-user-documentation`.
 3. You can then access a local copy of the documentation at <http://localhost:8080>.
 
 ## Running A Production Instance


### PR DESCRIPTION
### Background

Moving deployment image from [`hhvm`](https://hub.docker.com/r/hhvm/user-documentation/tags) to the `meta` org in Docker Hub, in order to resume publishing of [docs website](https://docs.hhvm.com/hhvm/). 

This will, upon push, update the [image name and tag](https://github.com/hhvm/user-documentation/blob/bd83afcde5581b7c88d420740ee29f9eed36cc55/.github/workflows/build-and-test.yml#L113) in downstream `deploy/*` tags, used for deployment to AWS ([`deploy/prod-main`](https://github.com/hhvm/user-documentation/tree/deploy/prod-main))

### Build Steps

 - Build and tag Docker image (prefix `hhvm-`)
 - Publish artefact to Docker Hub (`hhvm` → `meta` org)
 - Update image reference in `deploy/*` tag of this repo ([automatically](https://github.com/hhvm/user-documentation/commits/deploy/prod-main))
 - Kick off deployment (which will pull image as per reference above)

### Open Items

- [ ] Verify permissions for GitHub Actions to publish to _new repository_ under the `meta` org on Docker Hub
  _(provided that the GH Actions user has write-access to `meta`, the repository creation should follow naturally)_.