### PR TITLE
Shorten auto-generated resource name

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -140,7 +140,7 @@ jobs:
           terraform apply -auto-approve
         working-directory: .var/tmp/deploy/
         env:
-          WORKSPACE_NAME: staging-${{github.run_id}}
+          WORKSPACE_NAME: stag-${{github.run_id}}
       - name: Print staging host name
         id: print-staging-host-name
         run: terraform output -raw aws_lb_lb_dns_name
@@ -164,7 +164,7 @@ jobs:
         if: always()
         working-directory: .var/tmp/deploy/
         env:
-          WORKSPACE_NAME: staging-${{github.run_id}}
+          WORKSPACE_NAME: stag-${{github.run_id}}
       - name: Push to prod branch
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
Attempt to address the Terraform error where resource names have grown too long given the width of `github.run_id` in `var.name_prefix`:

 - WORKSPACE_NAME = "stag-${{github.run_id}}"
 - name_prefix = "docs-${terraform.workspace}"
 - **name = "${var.name_prefix}-https-${each.value.target_group_port}"**

```
│ Error: "name" cannot be longer than 32 characters
│ 
│   with module.ecs-fargate.module.ecs-fargate-service.module.ecs-alb.aws_lb_target_group.lb_https_tgs["forward_https_to_http"],
│   on .terraform/modules/ecs-fargate.ecs-fargate-service.ecs-alb/main.tf line 151, in resource "aws_lb_target_group" "lb_https_tgs":
│  151:   name                          = "${var.name_prefix}-https-${each.value.target_group_port}"
```

Reducing length of `staging` prefix in Terraform's `WORKSPACE_NAME` (as used in prefix).